### PR TITLE
BAU: support multiple databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,8 +103,11 @@ services:
       - 6379:6379
   assessment-store-data:
       image: postgres
+      volumes:
+        - ./docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
       restart: always
       environment:
         - POSTGRES_PASSWORD=password
+        - POSTGRES_MULTIPLE_DATABASES=postgres
       ports:
         - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,15 @@ services:
   account-store:
       build: 
         context: ../funding-service-design-account-store
-      command: ['flask', 'run', '--host', '0.0.0.0', '--port', '8080']
+      command: bash -c "flask db upgrade && flask run -p 8080 -h 0.0.0.0"
       environment:
         - FLASK_ENV=development
+        - DATABASE_URL=postgresql://postgres:password@database:5432/account_store
       volumes: ['../funding-service-design-account-store:/app']
       ports: 
         - 3003:8080
+      depends_on:
+        - database
   authenticator:
       build: 
         context: ../funding-service-design-authenticator
@@ -108,6 +111,6 @@ services:
       restart: always
       environment:
         - POSTGRES_PASSWORD=password
-        - POSTGRES_MULTIPLE_DATABASES=assessment_store
+        - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store
       ports:
         - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,9 @@ services:
       ports: 
         - 3005:8080
       environment:
-              - DATABASE_URL=postgresql://postgres:password@assessment-store-data:5432
+        - DATABASE_URL=postgresql://postgres:password@database:5432/assessment_store
       depends_on: 
-        - assessment-store-data
+        - database
   notification:
       build: 
         context: ../funding-service-design-notification
@@ -101,13 +101,13 @@ services:
     image: redis
     ports:
       - 6379:6379
-  assessment-store-data:
+  database:
       image: postgres
       volumes:
         - ./docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
       restart: always
       environment:
         - POSTGRES_PASSWORD=password
-        - POSTGRES_MULTIPLE_DATABASES=postgres
+        - POSTGRES_MULTIPLE_DATABASES=assessment_store
       ports:
         - 5432:5432

--- a/docker-postgresql-multiple-databases/Dockerfile
+++ b/docker-postgresql-multiple-databases/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres
+COPY create-multiple-postgresql-databases.sh /docker-entrypoint-initdb.d/

--- a/docker-postgresql-multiple-databases/LICENSE
+++ b/docker-postgresql-multiple-databases/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Mart Sõmermaa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-postgresql-multiple-databases/README.md
+++ b/docker-postgresql-multiple-databases/README.md
@@ -1,0 +1,57 @@
+# Using multiple databases with the official PostgreSQL Docker image
+
+The [official recommendation](https://hub.docker.com/_/postgres/) for creating
+multiple databases is as follows:
+
+*If you would like to do additional initialization in an image derived from
+this one, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts under
+`/docker-entrypoint-initdb.d` (creating the directory if necessary). After the
+entrypoint calls `initdb` to create the default `postgres` user and database,
+it will run any `*.sql` files and source any `*.sh` scripts found in that
+directory to do further initialization before starting the service.*
+
+This directory contains a script to create multiple databases using that
+mechanism.
+
+## Usage
+
+### By mounting a volume
+
+Clone the repository, mount its directory as a volume into
+`/docker-entrypoint-initdb.d` and declare database names separated by commas in
+`POSTGRES_MULTIPLE_DATABASES` environment variable as follows
+(`docker-compose` syntax):
+
+    myapp-postgresql:
+        image: postgres:9.6.2
+        volumes:
+            - ../docker-postgresql-multiple-databases:/docker-entrypoint-initdb.d
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES=db1,db2
+            - POSTGRES_USER=myapp
+            - POSTGRES_PASSWORD=
+
+### By building a custom image
+
+Clone the repository, build and push the image to your Docker repository,
+for example for Google Private Repository do the following:
+
+    docker build --tag=eu.gcr.io/your-project/postgres-multi-db .
+    gcloud docker -- push eu.gcr.io/your-project/postgres-multi-db
+
+You still need to pass the `POSTGRES_MULTIPLE_DATABASES` environment variable
+to the container:
+
+    myapp-postgresql:
+        image: eu.gcr.io/your-project/postgres-multi-db
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES=db1,db2
+            - POSTGRES_USER=myapp
+            - POSTGRES_PASSWORD=
+
+### Non-standard database names
+
+If you need to use non-standard database names (hyphens, uppercase letters etc), quote them in `POSTGRES_MULTIPLE_DATABASES`:
+
+        environment:
+            - POSTGRES_MULTIPLE_DATABASES="test-db-1","test-db-2"

--- a/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
+++ b/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function create_user_and_database() {
+	local database=$1
+	echo "  Creating user and database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	    CREATE USER $database;
+	    CREATE DATABASE $database;
+	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		create_user_and_database $db
+	done
+	echo "Multiple databases created"
+fi


### PR DESCRIPTION
Adds a mechanism for adding multiple databases to a single postgres image, as we have multiple apps which depend on postgres.

Adds assessment-store and account-store as initial users.