### PR TITLE
Adding fund store dependency to authenticator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,14 @@ services:
         - 3004:8080
       depends_on:
         - authenticator-data
+        - fund-store
         - account-store
         - notification
       environment: 
         - REDIS_INSTANCE_URI=redis://authenticator-data:6379
         - ACCOUNT_STORE_API_HOST=http://account-store:8080
         - APPLICATION_STORE_API_HOST=http://application-store:8080
+        - FUND_STORE_API_HOST=http://fund-store:8080
         - AUTHENTICATOR_HOST=http://localhost:3004
         - NOTIFICATION_SERVICE_HOST=http://notification:8080
         - APPLICANT_FRONTEND_HOST=http://localhost:3008


### PR DESCRIPTION
Add fund store dependency to authenticator to allow us to pull in contact details and support availability from fund-store