### PR TITLE
BAU: add override of form-runner base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,9 @@ services:
   form-runner:
     build: 
       context: ../funding-service-design-frontend
+      args:
+        # To use branch of digital-form-builder change 'latest' to an alternative tag from https://github.com/communitiesuk/digital-form-builder/pkgs/container/digital-form-builder-dluhc-runner/versions and run 'docker compose build form-runner'
+        - BASE_IMAGE_TAG=latest
     ports: 
       - 3009:3009
     environment:


### PR DESCRIPTION
Previously you had to make a change in your local frontend repo to use a different version of the form-runner base image. This change allows you to override it directly in the docker compose file.