### PR TITLE
Integrating fund-store and assessment-store in docker runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,7 @@ services:
     command: ['flask', 'run', '--host', '0.0.0.0', '--port', '8080']
     depends_on:
       - assessment-store
+      - fund-store
     environment:
       - FLASK_ENV=development
       - FUND_STORE_API_HOST=http://fund-store:8080


### PR DESCRIPTION
1. Docker runner had no defined route to fund-store from assessment-store - adding config to support