### PR TITLE
Fs 2277 feature toggle spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Copy `.env.example` to `.env` and ask another team member for the missing secret value
 * `docker compose up`
 * Apps should be running on localhost on the ports in the [docker-compose.yml](docker-compose.yml) `ports` key before the `:`
-* Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils (or any another depedency). To avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up` or just running `docker compose up --build` on its own.
+* Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils (or any another depedency). To avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up`.
 
 ## Troubleshooting
 * Check you have the `main` branch and latest revision of each repo checked out

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * Copy `.env.example` to `.env` and ask another team member for the missing secret value
 * `docker compose up`
 * Apps should be running on localhost on the ports in the [docker-compose.yml](docker-compose.yml) `ports` key before the `:`
+* Note: When testing locally using the docker runner, docker might use the cached version of fsd_utils (or any another depedency). To avoid this and pick up your intended changes, run `docker compose build <service_name> --no-cache` first before running `docker compose up` or just running `docker compose up --build` on its own.
 
 ## Troubleshooting
 * Check you have the `main` branch and latest revision of each repo checked out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,12 +42,12 @@ services:
       ports: 
         - 3004:8080
       depends_on:
-        - authenticator-data
         - fund-store
         - account-store
         - notification
+        - redis-data
       environment: 
-        - REDIS_INSTANCE_URI=redis://authenticator-data:6379
+        - REDIS_INSTANCE_URI=redis://redis-data:6379
         - ACCOUNT_STORE_API_HOST=http://account-store:8080
         - APPLICATION_STORE_API_HOST=http://application-store:8080
         - FUND_STORE_API_HOST=http://fund-store:8080
@@ -119,7 +119,7 @@ services:
       # Uncomment this to test file uploads once credentials are set in .env
       # - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       # - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  authenticator-data:
+  redis-data:
     image: redis
     ports:
       - 6379:6379
@@ -141,6 +141,8 @@ services:
     depends_on:
       - assessment-store
       - fund-store
+      - account-store
+      - redis-data
     environment:
       - FLASK_ENV=development
       - FUND_STORE_API_HOST=http://fund-store:8080
@@ -148,5 +150,6 @@ services:
       - ASSESSMENT_STORE_API_HOST=http://assessment-store:8080
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
       - AUTHENTICATOR_HOST=http://localhost:3004
+      - REDIS_INSTANCE_URI=redis://redis-data:6379
     ports: 
       - 3010:8080


### PR DESCRIPTION
FS-2277: Spike: Feature Toggles


### Change description
changed the name of authenticator_data to redis_data as this redis service is going to be used in other repos as well. also added a redis_uri envvar under the assessment service as we are testing the toggling spike using this repo to begin with.


### How to test
checkout to this branch along with [this ](https://github.com/communitiesuk/funding-service-design-utils/pull/62)in utils and [this ](https://github.com/communitiesuk/funding-service-design-assessment/pull/191)in assessment and see flagging functionality hidden from the user. (More info on running this E2E can be found in the description of the above assessment PR^.

See [this doc](https://digital.dclg.gov.uk/confluence/display/FS/Feature+Toggles+in+FSD) for more information on methodology, set up and how to use.
