### PR TITLE
FS-2184-download-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 * If dependencies have changed you may need to rebuild the docker images using `docker compose build`
 * To run an individual app rather than all of them, run `docker compose up appname` where app name is the key defined under `services` in [docker-compose.yml](docker-compose.yml) 
 * If you get an error about a database not existing, try running `docker compose down` followed by `docker compose up` this will remove and re-create any existing containers and volumes allowing the new databases to be created.
-* If file upload is not working with an error about credentials, you need to uncomment [these lines](https://github.com/communitiesuk/funding-service-design-docker-runner/blob/d13af481818fbd6398c3583e49a33edd6fb19496/docker-compose.yml#L114-L116) in `docker-compose.yml` and put the credentials in your `.env` file. The credentials are stored in the DLUHC BitWarden vault.
+* If file upload is not working with an error about credentials, you need to uncomment [these lines](https://github.com/communitiesuk/funding-service-design-docker-runner/blob/d13af481818fbd6398c3583e49a33edd6fb19496/docker-compose.yml#L114-L116) in `docker-compose.yml` and put the credentials in your `.env` file. The credentials are stored in the DLUHC BitWarden vault. (Same applies for file uploads in assessment or SSO in authentication for example.)
 
 
 ## Running e2e tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,5 +148,9 @@ services:
       - ASSESSMENT_STORE_API_HOST=http://assessment-store:8080
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
       - AUTHENTICATOR_HOST=http://localhost:3004
+      # Uncomment this to test file uploads once credentials are set in .env
+      # - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      # - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      # - AWS_BUCKET_NAME=${AWS_BUCKET_NAME}
     ports: 
       - 3010:8080


### PR DESCRIPTION
FS-2184: Application record for contracting

### Change description
In order to grab and download files from the S3 bucket whilst running locally via docker runner, we need to be able to connect to the AWS S3 bucket with our appropriate keys. We have added commented lines that set up the appropriate key envvars which can be uncommented and key values added in the .env file to test the file download functionality in assessment locally.

- [✅] README and other documentation has been updated / added (if needed)
- [✅] Commit messages are meaningful and follow good commit message guidelines


### How to test
1) Uncomment lines containing variables for AWS keys under environment in assessment section
2) Ask a member of DLUHC for the value of these keys and add them to your .env file
3) Build and run docker runner and you will be able to test file downloads in assessment locally
