### PR TITLE
point runner at runner repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - 3008:8080
   form-runner:
     build: 
-      context: ../funding-service-design-frontend
+      context: ../digital-form-builder/fsd_config
       args:
         # To use branch of digital-form-builder change 'latest' to an alternative tag from https://github.com/communitiesuk/digital-form-builder/pkgs/container/digital-form-builder-dluhc-runner/versions and run 'docker compose build form-runner'
         - BASE_IMAGE_TAG=latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   frontend:
     build:
       context: ../funding-service-design-frontend
-      dockerfile: app.dockerfile
+      dockerfile: Dockerfile
     volumes: ['../funding-service-design-frontend:/app']
     depends_on:
       - application-store
@@ -101,7 +101,8 @@ services:
       - 3008:8080
   form-runner:
     build: 
-      context: ../digital-form-builder/fsd_config
+      context: ../digital-form-builder
+      dockerfile: ./fsd_config/Dockerfile
       args:
         # To use branch of digital-form-builder change 'latest' to an alternative tag from https://github.com/communitiesuk/digital-form-builder/pkgs/container/digital-form-builder-dluhc-runner/versions and run 'docker compose build form-runner'
         - BASE_IMAGE_TAG=latest


### PR DESCRIPTION
Description
Move form JSON configuration and build step into the digital-form-builder repo

Currently, we maintain a forms_json folder in the frontend repo https://github.com/communitiesuk/funding-service-design-frontend/tree/main/form_jsons We then build a docker image in the frontend repo, using the base image built in another repo: https://github.com/communitiesuk/digital-form-builder

This adds a high level of complexity to orchestrating the build and deployment process.

This PR adds the form_json configuration into a self-contained configuration folder within the runner, the action that build the runner with these forms picks up the form configuration from this directory. It is extensible to more forms.

