### PR TITLE
BAU: Set default line endings as lf for db creation script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh eol=lf

--- a/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
+++ b/docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh
@@ -3,6 +3,10 @@
 set -e
 set -u
 
+if [ -z "${POSTGRES_USER}" ]; then
+  POSTGRES_USER="postgres"
+fi
+
 function create_user_and_database() {
 	local database=$1
 	echo "  Creating user and database '$database'"


### PR DESCRIPTION
### Change description

- Set default line endings as `LF` for database creation script (via `.gitattributes`)
- Set `POSTGRES_USER` to `postgres` if not explicitly set
- Make `create-multiple-postgresql-databases.sh` executable

This should prevent the common issue we see on windows where you first run `docker compose up` and the databases for relevant stores are not created, this was due to the file endings being `CRLF`, and potentially the script not being made executable.  After this change, running `docker compose up` should result in all containers starting normally, removing the need to create the databases manually and then restarting the store containers.