### PR TITLE
BAU: Change line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 docker-postgresql-multiple-databases/create-multiple-postgresql-databases.sh eol=lf
+docker-localstack/setup-awslocal.sh eol=lf


### PR DESCRIPTION
- Change line endings to LF for `setup-awslocal.sh`
- Also committed the changes for `setup-awslocal.sh` but doesn't show in the diff

This is to fix this issue:

```
2023-09-12 09:24:07 2023-09-12T08:24:07.584 ERROR
 --- [  MainThread] localstack.runtime.init    :
Error while running script Script(path='/etc/localstack/init/ready.d/setup-awslocal.sh', stage=READY, state=ERROR):
[Errno 2] No such file or directory: '/etc/localstack/init/ready.d/setup-awslocal.sh'
```