### PR TITLE
BAU Update localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 services:
   localstack:
-    image: localstack/localstack:2.2.0
+    image: localstack/localstack:3.7.2
     env_file: .awslocal.env
     environment:
       - SERVICES=s3,sqs
-      - DATA_DIR=/tmp/localstack/data
+      - PERSISTENCE=1
     ports:
       - 4566:4566 # LocalStack endpoint
       # - 4510-4559:4510-4559 # external services port range
     volumes:
       - ./docker-localstack:/etc/localstack/init/ready.d
-      - localstack:/tmp/localstack
+      - localstack:/var/lib/localstack
   fund-store:
     build:
       context: ../funding-service-design-fund-store

--- a/docker-localstack/setup-awslocal.sh
+++ b/docker-localstack/setup-awslocal.sh
@@ -6,7 +6,6 @@ if awslocal s3 ls | grep -q $AWS_BUCKET_NAME; then
 else
   awslocal s3api \
   create-bucket --bucket $AWS_BUCKET_NAME \
-  --create-bucket-configuration LocationConstraint=$AWS_REGION \
   --region $AWS_REGION
   echo "Created Bucket $AWS_BUCKET_NAME!"
   awslocal s3api \
@@ -29,7 +28,6 @@ if awslocal s3 ls | grep -q $AWS_MSG_BUCKET_NAME; then
 else
   awslocal s3api \
   create-bucket --bucket $AWS_MSG_BUCKET_NAME \
-  --create-bucket-configuration LocationConstraint=$AWS_REGION \
   --region $AWS_REGION
   echo "Created Bucket $AWS_BUCKET_NAME!"
   awslocal s3api \

--- a/docker-localstack/setup-awslocal.sh
+++ b/docker-localstack/setup-awslocal.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+# AWS_REGION is being overwritten by localstack on startup, the other environement vars passed in are respected
+# This should be addressed in a future release https://github.com/localstack/localstack/issues/11387
+AWS_REGION=eu-west-2
+AWS_DEFAULT_REGION=eu-west-2
+
 # Create the bucket using awslocal
 if awslocal s3 ls | grep -q $AWS_BUCKET_NAME; then
   echo "Bucket already exists!"
 else
   awslocal s3api \
   create-bucket --bucket $AWS_BUCKET_NAME \
+  --create-bucket-configuration LocationConstraint=$AWS_REGION \
   --region $AWS_REGION
   echo "Created Bucket $AWS_BUCKET_NAME!"
   awslocal s3api \
@@ -28,6 +34,7 @@ if awslocal s3 ls | grep -q $AWS_MSG_BUCKET_NAME; then
 else
   awslocal s3api \
   create-bucket --bucket $AWS_MSG_BUCKET_NAME \
+  --create-bucket-configuration LocationConstraint=$AWS_REGION \
   --region $AWS_REGION
   echo "Created Bucket $AWS_BUCKET_NAME!"
   awslocal s3api \


### PR DESCRIPTION
### Change description
Localstack on my machine (Mac OS Sonoma 14.6.1) is unable to run SQS.

It runs into the issue
`exception during call chain: Operation detection failed. Missing Action in request for query-protocol service ServiceModel(sqs)`

I haven't gotten to the bottom of exactly whats causing that but it appears to be an issue thats been fixed by (many!) subsequent versions of localstack.

Note `2.2.0` is 15 months old at the time of change.

Some configuration is simpler in newer versions of localstack and some of the configuration has been deprecated.

- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines