### PR TITLE
BAU: Remove dependencies on notification host and adds depends_on localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       - FUND_STORE_API_HOST=http://fund-store:8080
       - DATABASE_URL=postgresql://postgres:password@database:5432/application_store
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
-      - NOTIFICATION_SERVICE_HOST=http://notification:8080
     env_file: .awslocal.env
     ports:
       - 3002:8080
@@ -66,7 +65,7 @@ services:
       depends_on:
         - fund-store
         - account-store
-        - notification
+        - localstack
         - redis-data
       env_file: .awslocal.env
       environment:
@@ -75,7 +74,6 @@ services:
         - APPLICATION_STORE_API_HOST=http://application-store:8080
         - FUND_STORE_API_HOST=http://fund-store:8080
         - AUTHENTICATOR_HOST=http://localhost:3004
-        - NOTIFICATION_SERVICE_HOST=http://notification:8080
         - APPLICANT_FRONTEND_HOST=http://localhost:3008
         - ASSESSMENT_FRONTEND_HOST=http://localhost:3010
         #  Uncomment to test Azure AD locally once credentials are set in .env - see README
@@ -105,6 +103,8 @@ services:
       ports:
         - 3006:8080
         - 5686:5678
+      depends_on:
+        - localstack
       env_file: .awslocal.env
       environment:
         - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY:?err}


### PR DESCRIPTION
### Change description
Now we've moved to a queue based model the services don't depend on a HTTP connection to notification but on localstack as that provides the SQS queue.


- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
`docker compose up` should still work
