### PR TITLE
BAU Fix Redis client connection for the form builder adapter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
 
   form-runner:
     depends_on:
+      - redis-data
       - localstack
     build:
       context: ./apps/digital-form-builder-adapter
@@ -161,6 +162,8 @@ services:
       - LOGOUT_URL=https://authenticator.levellingup.gov.localhost:3004/sessions/sign-out
       - PRIVACY_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/privacy
       - ELIGIBILITY_RESULT_URL=https://frontend.levellingup.gov.localhost:3008/eligibility-result
+      - SINGLE_REDIS=true
+      - FORM_RUNNER_ADAPTER_REDIS_INSTANCE_URI=redis://redis-data:6379
     env_file: .awslocal.env
     networks:
       default:


### PR DESCRIPTION
### Change description
The form builder adapter is starting up and healthy but fails to connect to redis.

It looks like the redis client is failing to connect at startup and will then fail to be used in any subsequent requests to the form builder runner.

Set the redis uri which looks like a param that was recently added to the adapter. This allows the redis client to initialise as expected.

~~- [ ] README and other documentation has been updated / added (if needed)~~
- [x] Commit messages are meaningful and follow good commit message guidelines
