### PR TITLE
SPIKE: Use combined pre-award-stores repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,14 @@
 name: funding-service
 
 services:
-  fund-store:
-    build:
-      context: ./apps/funding-service-design-fund-store
-    command: bash -c "flask db upgrade && python -m scripts.load_all_fund_rounds && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
-    environment:
-      - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/fund_store
-    ports:
-      - 3001:8080
-      - 5681:5678
-    depends_on:
-      database:
-        condition: service_healthy
-    volumes: [ './apps/funding-service-design-fund-store:/app' ]
-    profiles: [ pre ]
 
-  application-store:
+  pre-award-stores:
     build:
-      context: ./apps/funding-service-design-application-store
-    command: bash -c "flask db upgrade && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
+      context: ./apps/funding-service-pre-award-stores
+    command: bash -c "flask db upgrade  && python -m fund_store.scripts.load_all_fund_rounds && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
     environment:
       - FLASK_ENV=development
-      - FUND_STORE_API_HOST=http://fund-store:8080
-      - DATABASE_URL=postgresql://postgres:password@database:5432/application_store
+      - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
     env_file: .awslocal.env
     ports:
@@ -35,7 +19,9 @@ services:
         condition: service_healthy
       localstack:
         condition: service_started
-    volumes: [ './apps/funding-service-design-application-store:/app' ]
+    volumes: 
+      - './apps/funding-service-pre-award-stores:/app'
+      - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
     profiles: [ pre ]
 
   account-store:
@@ -63,7 +49,7 @@ services:
       - 5685:5678
     environment:
       - DATABASE_URL=postgresql://postgres:password@database:5432/assessment_store
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
     env_file: .awslocal.env
     depends_on:
       database:
@@ -84,8 +70,8 @@ services:
       - localstack
     environment:
       - FLASK_ENV=development
-      - FUND_STORE_API_HOST=http://fund-store:8080
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
       - ASSESSMENT_STORE_API_HOST=http://assessment-store:8080
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
@@ -115,8 +101,8 @@ services:
       - localstack
     environment:
       - USE_LOCAL_DATA=False
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - FORMS_SERVICE_PUBLIC_HOST=http://form-runner.levellingup.gov.localhost:3009
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
@@ -152,7 +138,7 @@ services:
       - JWT_AUTH_COOKIE_NAME=fsd_user_token
       - JWT_REDIRECT_TO_AUTHENTICATION_URL=http://localhost:3004/sessions/sign-out
       - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ=="
-      - 'NODE_CONFIG={"safelist": ["application-store"]}'
+      - 'NODE_CONFIG={"safelist": ["pre-award-stores"]}'
       - CONTACT_US_URL=https://frontend.levellingup.gov.localhost:3008/contact_us
       - FEEDBACK_LINK=https://frontend.levellingup.gov.localhost:3008/feedback
       - COOKIE_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/cookie_policy
@@ -190,8 +176,8 @@ services:
     environment:
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
       - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008
       - ASSESSMENT_FRONTEND_HOST=https://assessment.levellingup.gov.localhost:3010
@@ -303,7 +289,7 @@ services:
     restart: always
     environment:
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,application_store,fund_store,data_store,data_store_test
+      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,data_store,data_store_test,pre_award_stores
     ports:
       - 5432:5432
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
       localstack:
         condition: service_started
-    volumes: 
+    volumes:
       - './apps/funding-service-pre-award-stores:/app'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
     profiles: [ pre ]

--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -6,7 +6,7 @@ fresh_clone=false
 git_log=false
 repo_root=$(dirname $(dirname $(realpath $0)))
 apps_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils")
+declare -a repos=("funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-pre-award-stores")
 
 while getopts 'fml' OPTION; do
     case "$OPTION" in


### PR DESCRIPTION
### Change description
- Replaces `fund-store` and `application-store` with `pre-award-stores`
- Requires `[uv](https://docs.astral.sh/uv/)` to be installed

Steps to run:
- Run the `reset-all-repos.sh` script to clone the new repo 
- Run `make up database` to create the new `pre-award-stores` database
- Manually checkout `spike/combine-fund-application-stores` in `apps/funding-service-pre-award-stores` 
- Manually run `uv run invoke -r fund_store recreate-local-db` to install ltree in the database (if this doesn't work you might need to run `uv sync` and then run the above command, and then `rm -rf .venv` to remove the local virtualenv)

- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_
