### PR TITLE
set localstack log level to warn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,6 +349,7 @@ services:
     environment:
       - SERVICES=s3,sqs
       - PERSISTENCE=1
+      - LS_LOG=warn
     ports:
       - 4566:4566 # LocalStack endpoint
       - 4510-4559:4510-4559 # external services port range


### PR DESCRIPTION
Set the LS_LOG level to `warn` to make the logs less noisy