### PR TITLE
FSPT-56: Add pre-award-stores repo to docker runner

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,6 +65,21 @@
             ]
         },
         {
+            "name": "Docker Runner: Pre-Award Stores",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5692
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/apps/funding-service-pre-award-stores",
+                    "remoteRoot": "."
+                }
+            ]
+        },
+        {
             "name": "Docker Runner: Authenticator",
             "type": "debugpy",
             "request": "attach",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     command: bash -c "flask db upgrade && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
     environment:
       - FLASK_ENV=development
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - DATABASE_URL=postgresql://postgres:password@database:5432/application_store
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
     env_file: .awslocal.env
@@ -111,6 +111,27 @@ services:
         condition: service_started
     profiles: [ pre ]
 
+  pre-award-stores:
+    build:
+      context: ./apps/funding-service-pre-award-stores
+    command: bash -c "flask db upgrade && python -m fund_store.scripts.load_all_fund_rounds && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
+    environment:
+      - FLASK_ENV=development
+      - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores
+    env_file: .awslocal.env
+    ports:
+      - 3012:8080
+      - 5692:5678
+    depends_on:
+      database:
+        condition: service_healthy
+      localstack:
+        condition: service_started
+    volumes:
+      - './apps/funding-service-pre-award-stores:/app'
+      - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
+    profiles: [ pre ]
+
   assessment:
     build:
       context: ./apps/funding-service-design-assessment
@@ -124,7 +145,7 @@ services:
       - localstack
     environment:
       - FLASK_ENV=development
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - APPLICATION_STORE_API_HOST=http://application-store:8080
       - ASSESSMENT_STORE_API_HOST=http://assessment-store:8080
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
@@ -157,7 +178,7 @@ services:
     environment:
       - USE_LOCAL_DATA=False
       - APPLICATION_STORE_API_HOST=http://application-store:8080
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - FORMS_SERVICE_PUBLIC_HOST=http://form-runner.levellingup.gov.localhost:3009
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
@@ -233,7 +254,7 @@ services:
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
       - APPLICATION_STORE_API_HOST=http://application-store:8080
-      - FUND_STORE_API_HOST=http://fund-store:8080
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
       - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008
       - ASSESSMENT_FRONTEND_HOST=https://assessment.levellingup.gov.localhost:3010
@@ -349,7 +370,7 @@ services:
     restart: always
     environment:
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,application_store,fund_store,data_store,data_store_test,fab_store
+      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,application_store,fund_store,data_store,data_store_test,fab_store,pre_award_stores,pre_award_stores_test
     ports:
       - 5432:5432
     healthcheck:

--- a/scripts/install-venv-all-repos.sh
+++ b/scripts/install-venv-all-repos.sh
@@ -5,7 +5,7 @@ build_static_files=false
 
 repo_root=$(dirname $(dirname $(realpath $0)))
 workspace_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "funding-service-design-post-award-data-store")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "funding-service-design-post-award-data-store")
 
 while getopts 'vps' OPTION; do
     case "$OPTION" in

--- a/scripts/migrate-data-to-pre-award-stores.sh
+++ b/scripts/migrate-data-to-pre-award-stores.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "............Creating pre_award_stores database............"
+docker compose exec database psql postgresql://postgres:password@database:5432/fund_store -c 'CREATE DATABASE pre_award_stores;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/fund_store -c 'CREATE DATABASE pre_award_stores_test;' # pragma: allowlist secret
+
+echo "............Creating pre-award-stores image and running database migrations............"
+docker compose up -d pre-award-stores
+docker compose exec pre-award-stores flask db upgrade
+
+echo "............Truncate any existing data in pre_award_stores database............"
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table assessment_field cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table fund cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table round cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table section cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table section_field cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table event cascade;' # pragma: allowlist secret
+docker compose exec database psql postgresql://postgres:password@database:5432/pre_award_stores -c 'truncate table form_name cascade;' # pragma: allowlist secret
+
+echo "............Copying data from fund_store to pre_award_stores............"
+docker compose exec database bash -c "pg_dump --verbose --data-only --format custom --exclude-table alembic_version postgresql://postgres:password@database:5432/fund_store | pg_restore --verbose --data-only --format custom --dbname postgresql://postgres:password@database:5432/pre_award_stores" # pragma: allowlist secret

--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -6,7 +6,7 @@ fresh_clone=false
 git_log=false
 repo_root=$(dirname $(dirname $(realpath $0)))
 apps_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
 
 while getopts 'fml' OPTION; do
     case "$OPTION" in


### PR DESCRIPTION
### Change description

- Add new pre-award-stores container and databases
- Point `FUND_STORE_API_HOST` to `pre-award-stores`
- Add migration script to copy `fund-store` data to `pre-award-stores`
- Update existing scripts and vscode launch config

- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Checkout this branch `feature/FSPT-56-add-combined-stores-repo`
- Run `./scripts/reset-all-repos.sh -f` script to pull down the `pre-award-stores` repo
- Run `./scripts/install-venv-all-repos.sh -p` to set up the venv for the repo 
- Run `./scripts/migrate-data-to-pre-award-stores.sh` to preserve data from `fund-store`
- Run things locally and check fund data is still being pulled through correctly

Or 
- Checkout this branch `feature/FSPT-56-add-combined-stores-repo`
- Run `./scripts/reset-all-repos.sh -f` script to pull down the `pre-award-stores` repo
- Run `./scripts/install-venv-all-repos.sh -p` to set up the venv for the repo 
- Stop your running containers
- Run `make up` to create the new containers and databases
- Run things locally and check fund data is still being pulled through correctly
