### PR TITLE
Automate fund-round creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 !/apps/.gitkeep
 /certs/*
 !/certs/.gitkeep
+/fund-round/*
+!/fund-round/.gitkeep

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -111,7 +111,7 @@ print_message "fund_store file: $FUND_STORE_FILE"
 print_prompt "Did you ruff formatted the form_runner? (1/0): "
 read -p "" confirm
 
-if [[ "$confirm" == "1" ]]; then
+if [[ "$confirm" == "0" ]]; then
     print_error "Exiting script. Come back after you ruff format the form_runner."
     exit 1
 fi
@@ -257,18 +257,18 @@ cp "$FUND_STORE_FILE" "$FUND_STORE_FILE_DEST"
 echo "Editing  $ASSESS_STORE_CONFIG_FILE"
 
 unscored_sections="[]"
-if [[ -f "$FUND_ROUND_DIR/$FUND_ROUND/mapping/unscored_sections.py" ]]; then
+if [[ -f "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store/unscored.py" ]]; then
     print_message "unscored_sections file found"
-    unscored_sections=$(cat "$FUND_ROUND_DIR/$FUND_ROUND/mapping/unscored_sections.py")
+    unscored_sections=$(cat "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store/unscored.py")
     unscored_sections=$(printf '%s' "$unscored_sections" | sed '1s/^//; 2,$s/^/        /; s/[\/&]/\\&/g; s/"/\\"/g; s/$/\\/')
 else
     print_message "No unscored_sections"
 fi
 
 scored_sections="[]"
-if [[ -f "$FUND_ROUND_DIR/$FUND_ROUND/mapping/scored_sections.py" ]]; then
+if [[ -f "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store/scored.py" ]]; then
     print_message "scored_sections file found"
-    scored_sections=$(cat "$FUND_ROUND_DIR/$FUND_ROUND/mapping/scored_sections.py")
+    scored_sections=$(cat "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store/scored.py")
     scored_sections=$(printf '%s' "$scored_sections" | sed '1s/^//; 2,$s/^/        /; s/[\/&]/\\&/g; s/"/\\"/g; s/$/\\/')
 else
     print_message "No scored_sections"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -3,19 +3,19 @@
 set -e  # Exit on errors
 
 print_header() {
-    echo -e "\n\e[1;34m$1\e[0m"
+    echo -e "\n\033[1;34m$1\033[0m"
 }
 
 print_prompt() {
-    echo -e -n "\e[1;33m$1\e[0m"
+    echo -e -n "\033[1;33m$1\033[0m"
 }
 
 print_message() {
-    echo -e "\e[1;37m$1\e[0m"
+    echo -e "\033[1;37m$1\033[0m"
 }
 
 print_error() {
-    echo -e "\e[1;31m$1\e[0m"
+    echo -e "\033[1;31m$1\033[0m"
 }
 
 create_git_branch() {
@@ -111,33 +111,19 @@ print_message "fund_store file: $FUND_STORE_FILE"
 echo "Format fund_store file"
 uv tool run ruff format $FUND_STORE_DIR
 
-FUND_ID=$(grep -oP '"id": "\K[^"]+' "$FUND_STORE_FILE" | head -n 1)
-FUND_SHORT_NAME=$(grep -oP '"short_name": "\K[^"]+' "$FUND_STORE_FILE" | head -n 1)
-ROUND_ID=$(grep -oP '"id": "\K[^"]+' "$FUND_STORE_FILE" | tail -n 1)
-ROUND_SHORT_NAME=$(grep -oP '"short_name": "\K[^"]+' "$FUND_STORE_FILE" | tail -n 1)
-CONTACT_EMAIL=$(grep -oP '"contact_email": "\K[^"]+' "$FUND_STORE_FILE" | head -n 1 | sed "s/'contact_email': '\([^']*\)'/\1/")
+FUND_ID=$(sed -n 's/.*"fund_id": *"\([^"]*\)".*/\1/p' "$FUND_STORE_FILE")
+FUND_SHORT_NAME=$(sed -n 's/.*"short_name": *"\([^"]*\)".*/\1/p' "$FUND_STORE_FILE" | head -n 1)
+ROUND_ID=$(sed -n 's/.*"id": *"\([^"]*\)".*/\1/p' "$FUND_STORE_FILE" | tail -n 1)
+ROUND_SHORT_NAME=$(sed -n 's/.*"short_name": *"\([^"]*\)".*/\1/p' "$FUND_STORE_FILE" | tail -n 1)
+CONTACT_EMAIL=$(sed -n 's/.*"contact_email": *"\([^"]*\)".*/\1/p' "$FUND_STORE_FILE")
 FUND_SHORT_NAME_LOWERCASE=$(echo "$FUND_SHORT_NAME" | tr 'A-Z' 'a-z')
 ROUND_SHORT_NAME_LOWERCASE=$(echo "$ROUND_SHORT_NAME" | tr 'A-Z' 'a-z')
 
-echo -e "Fund ID: \e[32m$FUND_ID\e[0m"
-echo -e "Fund Short Name: \e[32m$FUND_SHORT_NAME\e[0m"
-echo -e "Round ID: \e[32m$ROUND_ID\e[0m"
-echo -e "Round Short Name: \e[32m$ROUND_SHORT_NAME\e[0m"
-echo -e "Contact email: \e[32m$CONTACT_EMAIL\e[0m"
-
-echo -e "Sections:"
-grep -oP '"section_name": \{[^}]*\}' "$FUND_STORE_FILE" | while read -r section_line; do
-    SECTION_NAME=$(echo "$section_line" | grep -oP '"en": "\K[^"]+')
-
-    echo -e "- \e[32m$SECTION_NAME\e[0m"
-done
-
-echo -e "Forms:"
-grep -oP '"form_name_json": \{[^}]*\}' "$FUND_STORE_FILE" | while read -r form_name_json_line; do
-    FORM_NAME=$(echo "$form_name_json_line" | grep -oP '"en": "\K[^"]+')
-
-    echo -e "- \e[32m$FORM_NAME\e[0m"
-done
+echo -e "Fund ID: \033[32m$FUND_ID\033[0m"
+echo -e "Fund Short Name: \033[32m$FUND_SHORT_NAME\033[0m"
+echo -e "Round ID: \033[32m$ROUND_ID\033[0m"
+echo -e "Round Short Name: \033[32m$ROUND_SHORT_NAME\033[0m"
+echo -e "Contact email: \033[32m$CONTACT_EMAIL\033[0m"
 
 print_prompt "Is this information correct? (1/0): "
 read -p "" confirm
@@ -375,4 +361,4 @@ fi
 print_prompt "Press [Enter] to continue."
 read
 
-echo -e "\n\e[1;36mAll steps completed successfully!\e[0m"
+echo -e "\n\033[1;36mAll steps completed successfully!\033[0m"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -202,20 +202,29 @@ commit_changes \
 print_prompt "Press [Enter] to continue."
 read
 
-print_header "Step 3: Working on 'funding-service-design-frontend'"
+print_header "Step 3: Working on 'funding-service-pre-award-frontend'"
 print_message "Create new branch if needed"
 create_git_branch \
-    "$APPS_DIR/funding-service-design-frontend" \
+    "$APPS_DIR/funding-service-pre-award-frontend" \
     "run-$fund_short_name-$round_short_name"
 
-print_message "Copy html files to 'funding-service-design-frontend'"
-TEMPLATES_DIR="$APPS_DIR/funding-service-design-frontend/app/templates/all_questions/en"
+print_message "Copy html files to 'funding-service-pre-award-frontend'"
+TEMPLATES_DIR="$APPS_DIR/funding-service-pre-award-frontend/apply/templates/apply/all_questions/en"
 cp -r "$SELECTED_DIR/html/"* "$TEMPLATES_DIR/"
+
+ASSESS_CONFIG_FILE="$APPS_DIR/funding-service-pre-award-frontend/config/envs/development.py"
+echo "Editing  $ASSESS_CONFIG_FILE"
+sed -i'' -e "/\"roles\": \[/a \\
+            \"${fund_short_name_uppercase}_LEAD_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
+sed -i'' -e "/\"roles\": \[/a \\
+            \"${fund_short_name_uppercase}_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
+sed -i'' -e "/\"highest_role_map\": {/a \\
+            \"${fund_short_name_uppercase}\": \"DEBUG_USER_ROLE\",\\" "$ASSESS_CONFIG_FILE"
 
 print_message "Commit changes"
 commit_changes \
-    "$APPS_DIR/funding-service-design-frontend" \
-    "Adding ${fund_short_name}-${round_short_name} template"
+    "$APPS_DIR/funding-service-pre-award-frontend" \
+    "Adding ${fund_short_name}-${round_short_name} template and config"
 
 print_prompt "Press [Enter] to continue."
 read
@@ -255,14 +264,14 @@ else
     print_message "No scored_sections"
 fi
 
-sed -i '' -e "/fund_round_to_assessment_mapping = {/a \\
+sed -i'' -e "/fund_round_to_assessment_mapping = {/a \\
     \"$fund_id:$round_id\": {\\
         \"schema_id\": \"${fund_short_name}_${round_short_name}_assessment\",\\
         \"unscored_sections\": ${unscored_sections},\\
         \"scored_criteria\": ${scored_sections},\\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
-sed -i '' -e "/fund_round_data_key_mappings = {/a \\
+sed -i'' -e "/fund_round_data_key_mappings = {/a \\
     \"${fund_short_name}${round_short_name}\": {\\
         \"location\": None,\\
         \"asset_type\": None,\\
@@ -270,7 +279,7 @@ sed -i '' -e "/fund_round_data_key_mappings = {/a \\
         \"funding_two\": None,\\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
-sed -i '' -e "/fund_round_mapping_config = {/a \\
+sed -i'' -e "/fund_round_mapping_config = {/a \\
     \"${fund_short_name}${round_short_name}\": {\\
         \"fund_id\": \"$fund_id\",\\
         \"round_id\": \"$round_id\",\\
@@ -280,29 +289,6 @@ sed -i '' -e "/fund_round_mapping_config = {/a \\
 print_message "Commit changes"
 commit_changes \
     "$APPS_DIR/funding-service-pre-award-stores" \
-    "Adding ${fund_short_name}-${round_short_name} config"
-
-print_prompt "Press [Enter] to continue."
-read
-
-print_header "Step 5: Working on 'funding-service-design-assessment':"
-print_message "Create new branch if needed"
-create_git_branch \
-    "$APPS_DIR/funding-service-design-assessment" \
-    "run-$fund_short_name-$round_short_name"
-
-ASSESS_CONFIG_FILE="apps/funding-service-design-assessment/config/envs/development.py"
-echo "Editing  $ASSESS_CONFIG_FILE"
-sed -i '' -e "/\"roles\": \[/a \\
-            \"${fund_short_name_uppercase}_LEAD_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
-sed -i '' -e "/\"roles\": \[/a \\
-            \"${fund_short_name_uppercase}_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
-sed -i '' -e "/\"highest_role_map\": {/a \\
-            \"${fund_short_name_uppercase}\": \"DEBUG_USER_ROLE\",\\" "$ASSESS_CONFIG_FILE"
-
-print_message "Commit changes"
-commit_changes \
-    "$APPS_DIR/funding-service-design-assessment" \
     "Adding ${fund_short_name}-${round_short_name} config"
 
 print_prompt "Press [Enter] to continue."
@@ -345,7 +331,7 @@ sed -i'' -e "/APPLICATION_RECORD_TEMPLATE_ID = {/a \\
                 \"cy\": \"\"\\
             }\\
         }," "$NOTIFICATION_CONFIG_FILE"
-sed -i '' -e "/REPLY_TO_EMAILS_WITH_NOTIFY_ID = {/a \\
+sed -i'' -e "/REPLY_TO_EMAILS_WITH_NOTIFY_ID = {/a \\
         \"${contact_email}\": \"$email_id\",\\" "$NOTIFICATION_CONFIG_FILE"
 
 print_message "Commit changes"
@@ -355,8 +341,5 @@ commit_changes \
 
 print_prompt "Press [Enter] to continue."
 read
-
-# print_header "Step 8: Seed fund on 'make up':"
-# docker exec funding-service-pre-award-stores-1 python -m scripts.fund_round_loaders.load_fund_round_from_fab --fund_short_code $fund_short_name
 
 print_end "All steps completed successfully!"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -255,14 +255,14 @@ else
     print_message "No scored_sections"
 fi
 
-sed -i "/fund_round_to_assessment_mapping = {/a \\
+sed -i '' -e "/fund_round_to_assessment_mapping = {/a \\
     \"$fund_id:$round_id\": {\\
         \"schema_id\": \"${fund_short_name}_${round_short_name}_assessment\",\\
         \"unscored_sections\": ${unscored_sections},\\
         \"scored_criteria\": ${scored_sections},\\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
-sed -i "/fund_round_data_key_mappings = {/a \\
+sed -i '' -e "/fund_round_data_key_mappings = {/a \\
     \"${fund_short_name}${round_short_name}\": {\\
         \"location\": None,\\
         \"asset_type\": None,\\
@@ -270,7 +270,7 @@ sed -i "/fund_round_data_key_mappings = {/a \\
         \"funding_two\": None,\\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
-sed -i "/fund_round_mapping_config = {/a \\
+sed -i '' -e "/fund_round_mapping_config = {/a \\
     \"${fund_short_name}${round_short_name}\": {\\
         \"fund_id\": \"$fund_id\",\\
         \"round_id\": \"$round_id\",\\
@@ -293,11 +293,11 @@ create_git_branch \
 
 ASSESS_CONFIG_FILE="apps/funding-service-design-assessment/config/envs/development.py"
 echo "Editing  $ASSESS_CONFIG_FILE"
-sed -i "/\"roles\": \[/a \\
+sed -i '' -e "/\"roles\": \[/a \\
             \"${fund_short_name_uppercase}_LEAD_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
-sed -i "/\"roles\": \[/a \\
+sed -i '' -e "/\"roles\": \[/a \\
             \"${fund_short_name_uppercase}_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
-sed -i "/\"highest_role_map\": {/a \\
+sed -i '' -e "/\"highest_role_map\": {/a \\
             \"${fund_short_name_uppercase}\": \"DEBUG_USER_ROLE\",\\" "$ASSESS_CONFIG_FILE"
 
 print_message "Commit changes"
@@ -337,7 +337,7 @@ else
     email_id=$choice
 fi
 
-sed -i "/APPLICATION_RECORD_TEMPLATE_ID = {/a \\
+sed -i'' -e "/APPLICATION_RECORD_TEMPLATE_ID = {/a \\
         \"${fund_id}\": {\\
             \"fund_name\": \"${fund_short_name_uppercase}\",\\
             \"template_id\": {\\
@@ -345,7 +345,7 @@ sed -i "/APPLICATION_RECORD_TEMPLATE_ID = {/a \\
                 \"cy\": \"\"\\
             }\\
         }," "$NOTIFICATION_CONFIG_FILE"
-sed -i "/REPLY_TO_EMAILS_WITH_NOTIFY_ID = {/a \\
+sed -i '' -e "/REPLY_TO_EMAILS_WITH_NOTIFY_ID = {/a \\
         \"${contact_email}\": \"$email_id\",\\" "$NOTIFICATION_CONFIG_FILE"
 
 print_message "Commit changes"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -160,11 +160,12 @@ round_id=$(echo "$extracted_data" | jq -r '.round_id')
 round_short_name=$(echo "$extracted_data" | jq -r '.round_short_name' | tr '[:upper:]' '[:lower:]')
 contact_email=$(echo "$extracted_data" | jq -r '.contact_email')
 fund_short_name_uppercase=$(echo "$fund_short_name" | tr 'a-z' 'A-Z')
+round_short_name_uppercase=$(echo "$round_short_name" | tr 'a-z' 'A-Z')
 
 echo -e "Fund ID: \e[32m$fund_id\e[0m"
-echo -e "Fund Short Name: \e[32m$fund_short_name\e[0m"
+echo -e "Fund Short Name: \e[32m$fund_short_name_uppercase\e[0m"
 echo -e "Round ID: \e[32m$round_id\e[0m"
-echo -e "Round Short Name: \e[32m$round_short_name\e[0m"
+echo -e "Round Short Name: \e[32m$round_short_name_uppercase\e[0m"
 echo -e "Sections:"
 echo "$extracted_data" | jq -r '.sections[] | "  - Section Name: \(.name)\n    Form Name: \(.form // "N/A")"'
 
@@ -272,7 +273,7 @@ sed -i'' -e "/fund_round_to_assessment_mapping = {/a \\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
 sed -i'' -e "/fund_round_data_key_mappings = {/a \\
-    \"${fund_short_name}${round_short_name}\": {\\
+    \"${fund_short_name_uppercase}${round_short_name_uppercase}\": {\\
         \"location\": None,\\
         \"asset_type\": None,\\
         \"funding_one\": None,\\
@@ -280,7 +281,7 @@ sed -i'' -e "/fund_round_data_key_mappings = {/a \\
     }," "$ASSESS_STORE_CONFIG_FILE"
 
 sed -i'' -e "/fund_round_mapping_config = {/a \\
-    \"${fund_short_name}${round_short_name}\": {\\
+    \"${fund_short_name_uppercase}${round_short_name_uppercase}\": {\\
         \"fund_id\": \"$fund_id\",\\
         \"round_id\": \"$round_id\",\\
         \"type_of_application\": \"$fund_short_name\",\\

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -174,7 +174,11 @@ create_git_branch \
 
 print_message "Clean up html file of empty html classes 'funding-service-pre-award-frontend'"
 for file in "$FUND_ROUND_DIR/$FUND_ROUND/html"/*; do
-    sed -i 's/ <li class="">/<li>/g' $file
+    if  [[ "$OSTYPE" == "linux-gnu" ]]; then
+        sed -i 's/ <li class="">/<li>/g' $file
+    else
+        sed -i '' -e 's/ <li class="">/<li>/g' $file
+    fi
 done
 
 print_message "Copy html files to 'funding-service-pre-award-frontend'"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -108,13 +108,8 @@ FUND_STORE_DIR="$FUND_ROUND_DIR/$FUND_ROUND/fund_store"
 FUND_STORE_FILE=$(find $FUND_STORE_DIR -maxdepth 1 -type f -print -quit)
 print_message "fund_store file: $FUND_STORE_FILE"
 
-print_prompt "Did you ruff formatted the form_runner? (1/0): "
-read -p "" confirm
-
-if [[ "$confirm" == "0" ]]; then
-    print_error "Exiting script. Come back after you ruff format the form_runner."
-    exit 1
-fi
+echo "Format fund_store file"
+uv tool run ruff format $FUND_STORE_DIR
 
 FUND_ID=$(grep -oP '"id": "\K[^"]+' "$FUND_STORE_FILE" | head -n 1)
 FUND_SHORT_NAME=$(grep -oP '"short_name": "\K[^"]+' "$FUND_STORE_FILE" | head -n 1)
@@ -255,6 +250,9 @@ mkdir -p "$FUND_STORE_DEST_DIR"
 cp "$FUND_STORE_FILE" "$FUND_STORE_FILE_DEST"
 
 echo "Editing  $ASSESS_STORE_CONFIG_FILE"
+
+echo "Format assessment_store files"
+uv tool run ruff format "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store"
 
 unscored_sections="[]"
 if [[ -f "$FUND_ROUND_DIR/$FUND_ROUND/assessment_store/unscored.py" ]]; then

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -155,9 +155,9 @@ with open('$FUND_STORE_FILE') as f:
 
 # Parse extracted data
 fund_id=$(echo "$extracted_data" | jq -r '.fund_id')
-fund_short_name=$(echo "$extracted_data" | jq -r '.fund_short_name')
+fund_short_name=$(echo "$extracted_data" | jq -r '.fund_short_name' | tr '[:upper:]' '[:lower:]')
 round_id=$(echo "$extracted_data" | jq -r '.round_id')
-round_short_name=$(echo "$extracted_data" | jq -r '.round_short_name')
+round_short_name=$(echo "$extracted_data" | jq -r '.round_short_name' | tr '[:upper:]' '[:lower:]')
 contact_email=$(echo "$extracted_data" | jq -r '.contact_email')
 fund_short_name_uppercase=$(echo "$fund_short_name" | tr 'a-z' 'A-Z')
 
@@ -183,11 +183,11 @@ print_header "Step 2: Working on 'digital-form-builder-adapter'"
 print_message "Create new branch if needed"
 create_git_branch \
     "$APPS_DIR/digital-form-builder-adapter" \
-    "run-${fund_short_name,,}-${round_short_name,,}"
+    "run-$fund_short_name-$round_short_name"
 
 print_message "Copy form_runner files to 'digital-form-builder-adapter'"
 FORM_JSON_DIR="$APPS_DIR/digital-form-builder-adapter/fsd_config/form_jsons"
-FORM_DIR_NAME="${fund_short_name,,}_${round_short_name,,}"
+FORM_DIR_NAME="${fund_short_name}_${round_short_name}"
 
 print_message "Copying form_runner files to $FORM_JSON_DIR/$FORM_DIR_NAME"
 FORM_DEST_DIR="$FORM_JSON_DIR/$FORM_DIR_NAME"
@@ -206,7 +206,7 @@ print_header "Step 3: Working on 'funding-service-design-frontend'"
 print_message "Create new branch if needed"
 create_git_branch \
     "$APPS_DIR/funding-service-design-frontend" \
-    "run-${fund_short_name,,}-${round_short_name,,}"
+    "run-$fund_short_name-$round_short_name"
 
 print_message "Copy html files to 'funding-service-design-frontend'"
 TEMPLATES_DIR="$APPS_DIR/funding-service-design-frontend/app/templates/all_questions/en"
@@ -224,14 +224,14 @@ print_header "Step 4: Working on 'funding-service-pre-award-stores':"
 print_message "Create new branch if needed"
 create_git_branch \
     "$APPS_DIR/funding-service-pre-award-stores" \
-    "run-${fund_short_name,,}-${round_short_name,,}"
+    "run-$fund_short_name-$round_short_name"
 
 print_message "Copy fund_store file to 'funding-service-pre-award-stores':"
 FUND_STORE_DEST_DIR="$APPS_DIR/funding-service-pre-award-stores/fund_store/config/fund_loader_config/FAB"
 
 print_message "Copying form_runner files to $FUND_STORE_DEST_DIR"
 mkdir -p "$FUND_STORE_DEST_DIR"
-FUND_STORE_FILE_DEST="$FUND_STORE_DEST_DIR/${fund_short_name,,}_${round_short_name,,}.py"  # Lowercase
+FUND_STORE_FILE_DEST="$FUND_STORE_DEST_DIR/${fund_short_name}_${round_short_name}.py"  # Lowercase
 cp "$FUND_STORE_FILE" "$FUND_STORE_FILE_DEST"
 
 ASSESS_STORE_CONFIG_FILE="apps/funding-service-pre-award-stores/assessment_store/config/mappings/assessment_mapping_fund_round.py"
@@ -289,7 +289,7 @@ print_header "Step 5: Working on 'funding-service-design-assessment':"
 print_message "Create new branch if needed"
 create_git_branch \
     "$APPS_DIR/funding-service-design-assessment" \
-    "run-${fund_short_name,,}-${round_short_name,,}"
+    "run-$fund_short_name-$round_short_name"
 
 ASSESS_CONFIG_FILE="apps/funding-service-design-assessment/config/envs/development.py"
 echo "Editing  $ASSESS_CONFIG_FILE"
@@ -312,7 +312,7 @@ print_header "Step 6: Working on 'funding-service-design-notification':"
 print_message "Create new branch if needed"
 create_git_branch \
     "$APPS_DIR/funding-service-design-notification" \
-    "run-${fund_short_name,,}-${round_short_name,,}"
+    "run-$fund_short_name-$round_short_name"
 
 NOTIFICATION_CONFIG_FILE="apps/funding-service-design-notification/config/envs/default.py"
 echo "Editing  $NOTIFICATION_CONFIG_FILE"

--- a/scripts/fund-round-creator.sh
+++ b/scripts/fund-round-creator.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+set -e  # Exit on errors
+
+# Define directories
+FUND_ROUND_DIR="fund-round"
+APPS_DIR="apps"
+BRANCHES_CREATED=()  # Array to track created branches
+
+print_header() {
+    echo -e "\n\e[1;34m$1\e[0m"
+}
+
+print_prompt() {
+    echo -e -n "\e[1;33m$1\e[0m"
+}
+
+print_message() {
+    echo -e "\e[1;37m$1\e[0m"
+}
+
+print_error() {
+    echo -e "\e[1;31m$1\e[0m"
+}
+
+print_end() {
+    echo -e "\n\e[1;36m$1\e[0m"
+}
+
+# Function to cleanup branches
+cleanup_branches() {
+    echo -e "\n\e[1;31mAn error occurred. Cleaning up created branches...\e[0m"
+    for branch_info in "${BRANCHES_CREATED[@]}"; do
+        repo_path=$(echo "$branch_info" | cut -d '|' -f 1)
+        branch_name=$(echo "$branch_info" | cut -d '|' -f 2)
+        echo "Deleting branch $branch_name in $repo_path..."
+        cd "$repo_path"
+        git checkout main  # Fallback to main/master
+        git branch -D "$branch_name" || true  # Force delete branch if it exists
+        cd - >/dev/null
+    done
+}
+
+# Trap to handle script errors
+trap cleanup_branches ERR
+
+create_git_branch() {
+    local repo_path=$1
+    local branch_name=$2
+
+    cd "$repo_path"
+
+    # Check if branch already exists
+    if git branch --list $branch_name | grep -q $branch_name; then
+        print_message "Branch $branch_name already exists in $repo_path. Deleting existing branch..."
+        git checkout main
+        git branch -D "$branch_name"
+        git checkout -b "$branch_name"
+    else
+        print_message "Creating and switching to new branch $branch_name in $repo_path..."
+        git checkout -b "$branch_name"
+    fi
+
+    BRANCHES_CREATED+=("$repo_path|$branch_name")  # Track created branch
+
+    cd - >/dev/null
+}
+
+commit_changes() {
+    local repo_path=$1
+    local commit_message=$2
+
+    cd "$repo_path"
+
+    print_message "Git status:"
+    git status -u
+    print_message "Git diff:"
+    git --no-pager diff
+    git add .
+    git commit --no-verify -m "$commit_message"
+
+    cd - >/dev/null
+}
+
+
+###############################################################################
+#   Main script
+###############################################################################
+
+# List all directories inside the fund-round directory
+print_header "Available directories in $FUND_ROUND_DIR:"
+dirs=()
+i=1
+for dir in "$FUND_ROUND_DIR"/*; do
+    if [[ -d "$dir" ]]; then
+        dirs+=("$dir")
+        echo "$i) $(basename "$dir")"
+        ((i++))
+    fi
+done
+
+# Prompt the user to select a directory
+print_prompt "Select a directory by number: "
+read -p "" choice
+
+# Validate the user's choice
+if [[ "$choice" -ge 1 && "$choice" -le ${#dirs[@]} ]]; then
+    SELECTED_DIR="${dirs[$choice-1]}"
+    print_message "Selected directory: $(basename "$SELECTED_DIR")"
+else
+    print_error "Invalid choice. Exiting."
+    exit 1
+fi
+
+# Navigate to the fund_store directory
+FUND_STORE_DIR="$SELECTED_DIR/fund_store"
+if [[ ! -d "$FUND_STORE_DIR" ]]; then
+    print_error "Error: fund_store directory not found in $(basename "$SELECTED_DIR")."
+    exit 1
+fi
+
+print_header "Step 1: Extract and confirm fund and round information"
+FUND_STORE_FILE="$SELECTED_DIR/fund_store/round_config.py"
+if [[ ! -f "$FUND_STORE_FILE" ]]; then
+    print_error "Error: $FUND_STORE_FILE not found!"
+    exit 1
+fi
+
+# Extract fund and round information from the fund_store file
+extracted_data=$(python3 -c "
+import sys, json
+with open('$FUND_STORE_FILE') as f:
+    content = f.read()
+    start = content.find('LOADER_CONFIG = {')
+    if start == -1:
+        sys.exit('LOADER_CONFIG dictionary not found')
+    start += len('LOADER_CONFIG = ')
+    loader_config = eval(content[start:])
+    data = {
+        'fund_id': loader_config['fund_config']['id'],
+        'fund_short_name': loader_config['fund_config']['short_name'],
+        'round_id': loader_config['round_config']['id'],
+        'round_short_name': loader_config['round_config']['short_name'],
+        'contact_email': loader_config['round_config']['contact_email'],
+        'sections': [
+            {
+                'name': sec['section_name']['en'],
+                'form': sec['form_name_json']['en'] if 'form_name_json' in sec else None
+            }
+            for sec in loader_config['sections_config']
+        ]
+    }
+    print(json.dumps(data))
+")
+
+# Parse extracted data
+fund_id=$(echo "$extracted_data" | jq -r '.fund_id')
+fund_short_name=$(echo "$extracted_data" | jq -r '.fund_short_name')
+round_id=$(echo "$extracted_data" | jq -r '.round_id')
+round_short_name=$(echo "$extracted_data" | jq -r '.round_short_name')
+contact_email=$(echo "$extracted_data" | jq -r '.contact_email')
+fund_short_name_uppercase=$(echo "$fund_short_name" | tr 'a-z' 'A-Z')
+
+echo -e "Fund ID: \e[32m$fund_id\e[0m"
+echo -e "Fund Short Name: \e[32m$fund_short_name\e[0m"
+echo -e "Round ID: \e[32m$round_id\e[0m"
+echo -e "Round Short Name: \e[32m$round_short_name\e[0m"
+echo -e "Sections:"
+echo "$extracted_data" | jq -r '.sections[] | "  - Section Name: \(.name)\n    Form Name: \(.form // "N/A")"'
+
+print_prompt "Is this information correct? (1/0): "
+read -p "" confirm
+
+if [[ "$confirm" != "1" ]]; then
+    print_error "Exiting script. Please check the LOADER_CONFIG file."
+    exit 1
+fi
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 2: Working on 'digital-form-builder-adapter'"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/digital-form-builder-adapter" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+print_message "Copy form_runner files to 'digital-form-builder-adapter'"
+FORM_JSON_DIR="$APPS_DIR/digital-form-builder-adapter/fsd_config/form_jsons"
+FORM_DIR_NAME="${fund_short_name,,}_${round_short_name,,}"
+
+print_message "Copying form_runner files to $FORM_JSON_DIR/$FORM_DIR_NAME"
+FORM_DEST_DIR="$FORM_JSON_DIR/$FORM_DIR_NAME"
+mkdir -p "$FORM_DEST_DIR"
+cp -r "$SELECTED_DIR/form_runner/"* "$FORM_DEST_DIR/"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/digital-form-builder-adapter" \
+    "Adding ${fund_short_name}-${round_short_name} forms"
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 3: Working on 'funding-service-design-frontend'"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/funding-service-design-frontend" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+print_message "Copy html files to 'funding-service-design-frontend'"
+TEMPLATES_DIR="$APPS_DIR/funding-service-design-frontend/app/templates/all_questions/en"
+cp -r "$SELECTED_DIR/html/"* "$TEMPLATES_DIR/"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/funding-service-design-frontend" \
+    "Adding ${fund_short_name}-${round_short_name} template"
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 4: Working on 'funding-service-pre-award-stores':"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/funding-service-pre-award-stores" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+print_message "Copy fund_store file to 'funding-service-pre-award-stores':"
+FUND_STORE_DEST_DIR="$APPS_DIR/funding-service-pre-award-stores/fund_store/config/fund_loader_config/FAB"
+
+print_message "Copying form_runner files to $FUND_STORE_DEST_DIR"
+mkdir -p "$FUND_STORE_DEST_DIR"
+FUND_STORE_FILE_DEST="$FUND_STORE_DEST_DIR/${fund_short_name,,}_${round_short_name,,}.py"  # Lowercase
+cp "$FUND_STORE_FILE" "$FUND_STORE_FILE_DEST"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/funding-service-pre-award-stores" \
+    "Adding ${fund_short_name}-${round_short_name} script"
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 5: Working on 'funding-service-design-assessment':"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/funding-service-design-assessment" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+ASSESS_CONFIG_FILE="apps/funding-service-design-assessment/config/envs/development.py"
+echo "Editing  $ASSESS_CONFIG_FILE"
+sed -i "/\"roles\": \[/a \\
+            \"${fund_short_name_uppercase}_LEAD_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
+sed -i "/\"roles\": \[/a \\
+            \"${fund_short_name_uppercase}_ASSESSOR\",\\" "$ASSESS_CONFIG_FILE"
+sed -i "/\"highest_role_map\": {/a \\
+            \"${fund_short_name_uppercase}\": \"DEBUG_USER_ROLE\",\\" "$ASSESS_CONFIG_FILE"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/funding-service-design-assessment" \
+    "Adding ${fund_short_name}-${round_short_name} config"
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 6: Working on 'funding-service-design-notification':"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/funding-service-design-notification" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+NOTIFICATION_CONFIG_FILE="apps/funding-service-design-notification/config/envs/default.py"
+echo "Editing  $NOTIFICATION_CONFIG_FILE"
+
+template_id="6441da8a-1a42-4fe1-ad05-b7fb5f46a761"
+print_prompt "Provide a template id [$template_id]: "
+read -p "" choice
+
+if [[ -z "$choice" ]]; then
+    print_message "No input provided, using default: $template_id"
+else
+    template_id=$choice
+fi
+
+email_id="10668b8d-9472-4ce8-ae07-4fcc7bf93a9d"
+print_prompt "Provide an email id [$email_id]: "
+read -p "" choice
+
+if [[ -z "$choice" ]]; then
+    print_message "No input provided, using default: $email_id"
+else
+    email_id=$choice
+fi
+
+sed -i "/APPLICATION_RECORD_TEMPLATE_ID = {/a \\
+        \"${fund_id}\": {\\
+            \"fund_name\": \"${fund_short_name_uppercase}\",\\
+            \"template_id\": {\\
+                \"en\": \"$template_id\",\\
+                \"cy\": \"\"\\
+            }\\
+        }," "$NOTIFICATION_CONFIG_FILE"
+sed -i "/REPLY_TO_EMAILS_WITH_NOTIFY_ID = {/a \\
+        \"${contact_email}\": \"$email_id\",\\" "$NOTIFICATION_CONFIG_FILE"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/funding-service-design-notification" \
+    "Adding ${fund_short_name}-${round_short_name} config"
+
+print_prompt "Press [Enter] to continue."
+read
+
+print_header "Step 7: Working on 'funding-service-design-assessment-store':"
+print_message "Create new branch if needed"
+create_git_branch \
+    "$APPS_DIR/funding-service-design-assessment-store" \
+    "run-${fund_short_name,,}-${round_short_name,,}"
+
+ASSESS_STORE_CONFIG_FILE="apps/funding-service-design-assessment-store/config/mappings/assessment_mapping_fund_round.py"
+echo "Editing  $ASSESS_STORE_CONFIG_FILE"
+
+unscored_sections="[]"
+if [[ -f "$SELECTED_DIR/mapping/unscored_sections.py" ]]; then
+    print_message "unscored_sections file found"
+    unscored_sections=$(cat "$SELECTED_DIR/mapping/unscored_sections.py")
+    unscored_sections=$(printf '%s' "$unscored_sections" | sed '1s/^//; 2,$s/^/        /; s/[\/&]/\\&/g; s/"/\\"/g; s/$/\\/')
+else
+    print_message "No unscored_sections"
+fi
+
+scored_sections="[]"
+if [[ -f "$SELECTED_DIR/mapping/scored_sections.py" ]]; then
+    print_message "scored_sections file found"
+    scored_sections=$(cat "$SELECTED_DIR/mapping/scored_sections.py")
+    scored_sections=$(printf '%s' "$scored_sections" | sed '1s/^//; 2,$s/^/        /; s/[\/&]/\\&/g; s/"/\\"/g; s/$/\\/')
+else
+    print_message "No scored_sections"
+fi
+
+sed -i "/fund_round_to_assessment_mapping = {/a \\
+    \"$fund_id:$round_id\": {\\
+        \"schema_id\": \"${fund_short_name}_${round_short_name}_assessment\",\\
+        \"unscored_sections\": ${unscored_sections},\\
+        \"scored_criteria\": ${scored_sections},\\
+    }," "$ASSESS_STORE_CONFIG_FILE"
+
+sed -i "/fund_round_data_key_mappings = {/a \\
+    \"${fund_short_name}${round_short_name}\": {\\
+        \"location\": None,\\
+        \"asset_type\": None,\\
+        \"funding_one\": None,\\
+        \"funding_two\": None,\\
+    }," "$ASSESS_STORE_CONFIG_FILE"
+
+sed -i "/fund_round_mapping_config = {/a \\
+    \"${fund_short_name}${round_short_name}\": {\\
+        \"fund_id\": \"$fund_id\",\\
+        \"round_id\": \"$round_id\",\\
+        \"type_of_application\": \"$fund_short_name\",\\
+    }," "$ASSESS_STORE_CONFIG_FILE"
+
+print_message "Commit changes"
+commit_changes \
+    "$APPS_DIR/funding-service-design-assessment-store" \
+    "Adding ${fund_short_name}-${round_short_name} config"
+
+# print_header "Step 8: Seed fund on 'make up':"
+# docker exec funding-service-pre-award-stores-1 python -m scripts.fund_round_loaders.load_fund_round_from_fab --fund_short_code $fund_short_name
+
+print_end "All steps completed successfully!"


### PR DESCRIPTION
Automates the whole setting up Apply and Assess to use a FAB created fund, round and form. 
Lots of our code is moved at the moment, so this will soon break, but if there is any value in this script, we will update it.

Pre-requisites:
1. Be checked out on `main` on the following repos, pull latest changes, stash uncommitted changes. The script will create a new branch on multiple repos with the required config.
2. You can either create your own FAB fund/round/form or ask for a sample; you need to extract the config from FAB and paste it in `/fund-round/.`. 
3. You might need to clean up a bit FAB's exported stuff. Name the dir nicely without special chars/spaces.

Optional step:
Do a `make down`. Keep things clean.

### How to test
1. Make sure your FAB directory with the `html`, `fund-store` and `form-runner` config are inside `/fund-round`
2. Run `./scripts/fund-round-creator.sh` and follow the prompt
3. Until [PR](https://github.com/communitiesuk/funding-service-pre-award-stores/pull/13) is merged you will have to run seed the fund manually: 
```bash
docker exec funding-service-pre-award-stores-1 python -m fund_store.scripts.fund_round_loaders.load_fund_round_from_fab --fund_short_code <fund-short-name-uppercase>
```
4. `make up`

You can now go to:
https://frontend.levellingup.gov.localhost:3008/funding-round/fund-short-name/round-short-name
Create a quick application.

You can now go to:
https://assessment.levellingup.gov.localhost:3010
You can see you application there.
