### PR TITLE
FSPT-55: Update docker runner to switch use pre-award-stores instead of application-store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/assessment_store
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
     env_file: .awslocal.env
     depends_on:
       database:
@@ -124,6 +124,8 @@ services:
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores
+      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
+      - ACCOUNT_STORE_API_HOST=http://account-store:8080
     env_file: .awslocal.env
     ports:
       - 3012:8080
@@ -152,7 +154,7 @@ services:
     environment:
       - FLASK_ENV=development
       - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
       - ASSESSMENT_STORE_API_HOST=http://assessment-store:8080
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
@@ -183,7 +185,7 @@ services:
       - localstack
     environment:
       - USE_LOCAL_DATA=False
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
+      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
       - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - FORMS_SERVICE_PUBLIC_HOST=http://form-runner.levellingup.gov.localhost:3009
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
@@ -220,7 +222,7 @@ services:
       - JWT_AUTH_COOKIE_NAME=fsd_user_token
       - JWT_REDIRECT_TO_AUTHENTICATION_URL=http://localhost:3004/sessions/sign-out
       - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ=="
-      - 'NODE_CONFIG={"safelist": ["application-store"]}'
+      - 'NODE_CONFIG={"safelist": ["application-store", "pre-award-stores"]}'
       - CONTACT_US_URL=https://frontend.levellingup.gov.localhost:3008/contact_us
       - FEEDBACK_LINK=https://frontend.levellingup.gov.localhost:3008/feedback
       - COOKIE_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/cookie_policy
@@ -259,7 +261,6 @@ services:
     environment:
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
-      - APPLICATION_STORE_API_HOST=http://application-store:8080
       - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:3004
       - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008


### PR DESCRIPTION
### Change description
Points `APPLICATION_STORE_API_HOST` to `pre-award-stores`

- [ ] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Checkout this branch `feature/FSPT-55-update-docker-runner-for-application-store-merge`
- Run `./scripts/reset-all-repos.sh -m` script to pull down the latest `pre-award-stores` repo
- Run `./scripts/install-venv-all-repos.sh -p` to resync the venv and make sure pre-commit hooks are up to date 
- Stop your running containers
- Rebuild the `pre-award-stores` container with `docker compose build pre-award-stores`
- Run `make up` to restart your containers
- Run things locally and check everything still works correctly (you should be able to submit and application and see it pulled through to assess)
