### PR TITLE
Remove fund-store references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,24 +31,6 @@ services:
         aliases:
           - fund-application-builder.levellingup.gov.localhost
 
-  fund-store:
-    build:
-      context: ./apps/funding-service-design-fund-store
-    command: bash -c "flask db upgrade && python -m scripts.load_all_fund_rounds && python -m debugpy --listen 0.0.0.0:5678 -m wsgi"
-    environment:
-      - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/fund_store
-    ports:
-      - 3001:8080
-      - 5681:5678
-    depends_on:
-      database:
-        condition: service_healthy
-    volumes:
-      - './apps/funding-service-design-fund-store:/app'
-      - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
-    profiles: [ pre ]
-
   application-store:
     build:
       context: ./apps/funding-service-design-application-store

--- a/scripts/install-venv-all-repos.sh
+++ b/scripts/install-venv-all-repos.sh
@@ -5,7 +5,7 @@ build_static_files=false
 
 repo_root=$(dirname $(dirname $(realpath $0)))
 workspace_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "funding-service-design-post-award-data-store")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-notification" "funding-service-design-post-award-data-store")
 
 while getopts 'vps' OPTION; do
     case "$OPTION" in

--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -6,7 +6,7 @@ fresh_clone=false
 git_log=false
 repo_root=$(dirname $(dirname $(realpath $0)))
 apps_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-fund-store" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-assessment" "funding-service-design-assessment-store" "funding-service-design-account-store" "funding-service-design-application-store" "funding-service-design-frontend" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
 
 while getopts 'fml' OPTION; do
     case "$OPTION" in


### PR DESCRIPTION
This service was consolidated into the pre-award-stores service a week ago. We no longer need to have it running as a separate service or manage that repo locally.

https://mhclgdigital.atlassian.net/browse/FSPT-54