### PR TITLE
Adjust output of git log for repos

### DIFF
--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -68,15 +68,18 @@ if [ "$reset_to_main" = true ] ; then
 fi
 
 if [ "$git_log" = true ] ; then
-    echo Running git log
+    echo -e "Running git log\n"
+
+    outfile=$(mktemp)
+
+    echo $'Repository\tBranch name\tCommit hash' > ${outfile}
 
     for repo in "${repos[@]}"
     do
-    echo -------------------------------------------------------------------------
     cd ${apps_dir}/$repo
-    echo $repo
-    git log -n 1 --format=format:%H
+    echo -e "$repo\t$(git rev-parse --abbrev-ref HEAD)\t$(git rev-parse --short=8 HEAD)" >> ${outfile}
     done
-    echo -------------------------------------------------------------------------
     cd ${repo_root}
+
+    cat ${outfile} | sort | column -t -s $'\t'
 fi


### PR DESCRIPTION
Make the output of `./scripts/reset-all-repos.sh -l` a bit more useful.

## Was
```
❯ ./scripts/reset-all-repos.sh -l
Showing latest commit hash for all repos
============================================
Fresh clone repos: false
Reset all to main: false
Show latest commit: true
============================================
Running git log
-------------------------------------------------------------------------
funding-service-design-fund-application-builder
f3cc0d74fd257a773f03d26af70be3bec426911b
-------------------------------------------------------------------------
funding-service-pre-award-stores
9c6ca3f158e23b6ff869e2a81cc55e37d31c0b0e
-------------------------------------------------------------------------
funding-service-design-authenticator
ba1517202e5670a70f0092ef99a3e6456a5095bc
-------------------------------------------------------------------------
funding-service-design-assessment
fdbf18de6c21531f141eb2f347c18c88b252d5d6
-------------------------------------------------------------------------
funding-service-design-assessment-store
b2866e88c34c83396f3805c08a9db550d72c5ec4
-------------------------------------------------------------------------
funding-service-design-account-store
2b586558d9a84e1310abb7666eecd3d311060f7a
-------------------------------------------------------------------------
funding-service-design-frontend
d7d3ea8ff8aba2b69ffd700fdad440d531987541
-------------------------------------------------------------------------
funding-service-design-notification
1aa53d87d438aafe6097d82fc26d5c3773770a03
-------------------------------------------------------------------------
digital-form-builder-adapter
b031d74a71b3d0138a070939ee7d43f5c5d86d81
-------------------------------------------------------------------------
funding-service-design-post-award-data-store
9032405d3e511e54779b327e5a26923b8fea724f
-------------------------------------------------------------------------
funding-service-design-utils
2e3c4d740e7e0bbf5a06f4e97b1fdb5ece55c297
-------------------------------------------------------------------------
funding-service-design-workflows
b4a86a9348affe22d2e02045758abc9a25bb8c04
-------------------------------------------------------------------------
```

## Is now

```
❯ ./scripts/reset-all-repos.sh -l
Showing latest commit hash for all repos
============================================
Fresh clone repos: false
Reset all to main: false
Show latest commit: true
============================================
Running git log

Repository                                       Branch name                  Commit hash
digital-form-builder-adapter                     fix/e2e-tests-aws-account    b031d74a
funding-service-design-account-store             fix/e2e-secrets              2b586558
funding-service-design-assessment                fix/e2e-secrets              fdbf18de
funding-service-design-assessment-store          main                         b2866e88
funding-service-design-authenticator             fix/e2e-secrets              ba151720
funding-service-design-frontend                  fix/e2e-secrets              d7d3ea8f
funding-service-design-fund-application-builder  main                         f3cc0d74
funding-service-design-notification              bau/pass-aws-account-secret  1aa53d87
funding-service-design-post-award-data-store     main                         9032405d
funding-service-design-utils                     main                         2e3c4d74
funding-service-design-workflows                 main                         b4a86a93
funding-service-pre-award-stores                 main                         9c6ca3f1
```