### PR TITLE
BAU - Adding launch.json debug config for FAB

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,6 +80,21 @@
             ]
         },
         {
+            "name": "Docker Runner: Fund Application Builder",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5690
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/apps/funding-service-design-fund-application-builder",
+                    "remoteRoot": "."
+                }
+            ]
+        },
+        {
             "name": "Docker Runner: Notification",
             "type": "debugpy",
             "request": "attach",
@@ -119,6 +134,7 @@
                 "Docker Runner: Authenticator",
                 "Docker Runner: Data Store",
                 "Docker Runner: Frontend",
+                "Docker Runner: Fund Application Builder",
                 "Docker Runner: Notification",
                 "Docker Runner: Pre-Award Stores"
             ],


### PR DESCRIPTION
Quick change to add a debug configuration for the Fund Application Builder (FAB) application to `.vscode/launch.json` to allow developers to debug FAB locally.