### PR TITLE
FSPT-38: Add VS Code debug config for all services

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,21 +35,6 @@
             ]
         },
         {
-            "name": "Docker Runner: Pre-Award Stores",
-            "type": "debugpy",
-            "request": "attach",
-            "connect": {
-                "host": "localhost",
-                "port": 5692
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}/apps/funding-service-pre-award-stores",
-                    "remoteRoot": "."
-                }
-            ]
-        },
-        {
             "name": "Docker Runner: Authenticator",
             "type": "debugpy",
             "request": "attach",
@@ -108,6 +93,36 @@
                     "remoteRoot": "."
                 }
             ]
+        },
+        {
+            "name": "Docker Runner: Pre-Award Stores",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5692
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/apps/funding-service-pre-award-stores",
+                    "remoteRoot": "."
+                }
+            ]
+        },
+    ],
+    "compounds": [
+        {
+            "name": "Docker Runner: ALL THE APPS",
+            "configurations": [
+                "Docker Runner: Account Store",
+                "Docker Runner: Assessment",
+                "Docker Runner: Authenticator",
+                "Docker Runner: Data Store",
+                "Docker Runner: Frontend",
+                "Docker Runner: Notification",
+                "Docker Runner: Pre-Award Stores"
+            ],
+            "stopAll": true
         }
     ]
 }


### PR DESCRIPTION
### Change description
Adds a `compounds` block to the VS launch.json. This adds a new VS Code debug option that will attach the debugger to all the apps run by the docker runner.

- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_
