### PR TITLE
FS-4877 - Fix local testing of FAB when using global Docker runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,7 @@ services:
     restart: always
     environment:
       - POSTGRES_PASSWORD=password
-      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,data_store,data_store_test,fab_store,pre_award_stores,pre_award_stores_test
+      - POSTGRES_MULTIPLE_DATABASES=assessment_store,account_store,data_store,data_store_test,fab_store,fab_store_test,pre_award_stores,pre_award_stores_test
     ports:
       - 5432:5432
     healthcheck:


### PR DESCRIPTION
### Ticket

[Fix local testing of FAB when using global Docker Runner](https://mhclgdigital.atlassian.net/browse/FS-4877)

### Description

Currently if we use the Funding Service-wide Docker runner to spin up apps locally, we get SQL connection issues when we try to run unit tests in FAB (`uv run pytest .`). This is because these unit tests rely on the existence of a database fab_unit_test the global Docker Runner doesn’t provide this.

This change is to add a new `fab_store_test` to the list of databases created in the local Postgres instance.