### PR TITLE
Running seed script on account-store startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     command: 
       bash -c "
       flask db upgrade && \
-      python -m invoke seed_local_account_store && \
+      python -m invoke seed-local-account-store && \
       python -m debugpy --listen 0.0.0.0:5678 -m wsgi
       "
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,12 @@ services:
   account-store:
     build:
       context: ./apps/funding-service-design-account-store
-    command: [ "sh", "-c", "flask db upgrade && python -m debugpy --listen 0.0.0.0:5678 -m wsgi" ]
+    command: 
+      bash -c "
+      flask db upgrade && \
+      python -m invoke seed_local_account_store && \
+      python -m debugpy --listen 0.0.0.0:5678 -m wsgi
+      "
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/account_store


### PR DESCRIPTION
A separate PR on [account-store](https://github.com/communitiesuk/funding-service-design-account-store/pull/286) adds a seeding script to create the `lead_assessor@example.com` account if it doesn't already exist.

This PR adds a call to that script to the `account-store` startup routine in the docker runner