### PR TITLE
Add APPLY_HOST for pre-award-frontend app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ services:
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
       - ACCOUNT_STORE_API_HOST=http://account-store:8080
+      - APPLY_HOST=frontend.levellingup.gov.localhost:3008
       - FLASK_DEBUG=1
       - FLASK_ENV=development
       - REDIS_INSTANCE_URI=redis://redis-data:6379


### PR DESCRIPTION
This is because the combined frontend is switching over to using `host_matching`, where all routes are explicitly associated with a single host/domain.