### PR TITLE
FSPT-190 Configure docker runner to use pre award stores for account store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores
       - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
-      - ACCOUNT_STORE_API_HOST=http://account-store:8080
+      - ACCOUNT_STORE_API_HOST=http://pre-award-stores:8080/account
       - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
     env_file: .awslocal.env
     ports:
@@ -109,7 +109,7 @@ services:
       - FORMS_SERVICE_PUBLIC_HOST=http://form-runner.levellingup.gov.localhost:3009
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
-      - ACCOUNT_STORE_API_HOST=http://account-store:8080
+      - ACCOUNT_STORE_API_HOST=http://pre-award-stores:8080/account
       - APPLY_HOST=frontend.levellingup.gov.localhost:3008
       - ASSESS_HOST=assessment.levellingup.gov.localhost:3010
       - FLASK_DEBUG=1
@@ -185,7 +185,7 @@ services:
       - .awslocal.env
     environment:
       - REDIS_INSTANCE_URI=redis://redis-data:6379
-      - ACCOUNT_STORE_API_HOST=http://account-store:8080
+      - ACCOUNT_STORE_API_HOST=http://pre-award-stores:8080/account
       - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
       - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,28 +33,6 @@ services:
         aliases:
           - fund-application-builder.levellingup.gov.localhost
 
-  account-store:
-    build:
-      context: ./apps/funding-service-design-account-store
-    command:
-      bash -c "
-      flask db upgrade && \
-      python -m invoke seed-local-account-store && \
-      python -m debugpy --listen 0.0.0.0:5678 -m wsgi
-      "
-    environment:
-      - FLASK_ENV=development
-      - DATABASE_URL=postgresql://postgres:password@database:5432/account_store
-    volumes:
-      - './apps/funding-service-design-account-store:/app'
-      - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
-    ports:
-      - 3003:8080
-      - 5683:5678
-    depends_on:
-      database:
-        condition: service_healthy
-
   pre-award-stores:
     build:
       context: ./apps/funding-service-pre-award-stores
@@ -63,7 +41,8 @@ services:
       flask db upgrade && \
       python -m fund_store.scripts.load_all_fund_rounds && \
       python -m fund_store.scripts.fund_round_loaders.load_fund_round_from_fab --fund_short_code CTDF && \
-      python -m invoke -r assessment_store seed-local-assessment-store-db && \
+      python -m invoke assessment.seed-local-assessment-store-db && \
+      python -m invoke account.seed-local-account-store && \
       python -m debugpy --listen 0.0.0.0:5678 -m wsgi
       "
     environment:

--- a/scripts/install-venv-all-repos.sh
+++ b/scripts/install-venv-all-repos.sh
@@ -5,7 +5,7 @@ build_static_files=false
 
 repo_root=$(dirname $(dirname $(realpath $0)))
 workspace_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-account-store" "funding-service-pre-award-frontend" "funding-service-design-notification" "funding-service-design-post-award-data-store")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-pre-award-frontend" "funding-service-design-notification" "funding-service-design-post-award-data-store")
 
 while getopts 'vps' OPTION; do
     case "$OPTION" in

--- a/scripts/reset-all-repos.sh
+++ b/scripts/reset-all-repos.sh
@@ -6,7 +6,7 @@ fresh_clone=false
 git_log=false
 repo_root=$(dirname $(dirname $(realpath $0)))
 apps_dir="${repo_root}/apps"
-declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-design-account-store" "funding-service-pre-award-frontend" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
+declare -a repos=("funding-service-design-fund-application-builder" "funding-service-pre-award-stores" "funding-service-design-authenticator" "funding-service-pre-award-frontend" "funding-service-design-notification" "digital-form-builder-adapter" "funding-service-design-post-award-data-store" "funding-service-design-utils" "funding-service-design-workflows")
 
 while getopts 'fml' OPTION; do
     case "$OPTION" in


### PR DESCRIPTION
Points all the account store hosts at the pre-award-store, a separate PR will remove the account store when we've released this change in production.

Depends on https://github.com/communitiesuk/funding-service-pre-award-stores/pull/58