### PR TITLE
Hook up certificates bundle for API HTTPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL := bash
 .PHONY: certs
 certs:
 	mkdir -p certs
-	mkcert -install
-	mkcert -cert-file certs/cert.pem -key-file certs/key.pem "*.levellingup.gov.localhost"
+	CAROOT=certs mkcert -install
+	CAROOT=certs mkcert -cert-file certs/cert.pem -key-file certs/key.pem "*.levellingup.gov.localhost"
 
 
 # <-- Janky block to allow `make up` / `make pre up` / `make post up`, and same for `make ... down` -->

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Required setup
 1. Copy `.env.example` to `.env` and fill in any required missing values.
 2. Edit your `/etc/hosts` file and add the following line at the end:
-  * `127.0.0.1    submit-monitoring-data.levellingup.gov.localhost find-monitoring-data.levellingup.gov.localhost authenticator.levellingup.gov.localhost assessment.levellingup.gov.localhost frontend.levellingup.gov.localhost localstack fund-application-builder.levellingup.gov.localhost`
+  * `127.0.0.1    submit-monitoring-data.levellingup.gov.localhost find-monitoring-data.levellingup.gov.localhost authenticator.levellingup.gov.localhost assessment.levellingup.gov.localhost frontend.levellingup.gov.localhost localstack fund-application-builder.levellingup.gov.localhost api.levellingup.gov.localhost form-runner.levellingup.gov.localhost`
 3. Run `./scripts/manage-repos.sh -f` to git clone all repos into `./apps`
 4. Run `./scripts/install-venv-all-repos.sh -v -p -s` to create and populate venvs in all repos and install pre-commit hooks.
   * Note: there are some pre-existing issues with the script sometimes not picking the correct python version, may need some manual finagling until that is addressed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - './apps/funding-service-pre-award-frontend:/app'
       - './certs:/app-certs'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
-    command: > 
+    command: >
       bash -c "
         cp /app-certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
         update-ca-certificates && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,22 +38,25 @@ services:
       context: ./apps/funding-service-pre-award-stores
     command: >
       bash -c "
+      cp /app-certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
+      update-ca-certificates && \
       flask db upgrade && \
       python -m fund_store.scripts.load_all_fund_rounds && \
       python -m fund_store.scripts.fund_round_loaders.load_fund_round_from_fab --seed_all_funds True && \
       python -m invoke assessment.seed-local-assessment-store-db && \
       python -m invoke account.seed-local-account-store && \
-      python -m debugpy --listen 0.0.0.0:5678 -m flask -A app:create_app run --host 0.0.0.0 --port 8080
+      python -m debugpy --listen 0.0.0.0:5678 -m flask -A app:create_app run --host 0.0.0.0 --port 3012 --cert=/app-certs/cert.pem --key=/app-certs/key.pem
       "
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores
-      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
-      - ACCOUNT_STORE_API_HOST=http://pre-award-stores:8080/account
-      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
+      - FUND_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/fund
+      - ACCOUNT_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/account
+      - APPLICATION_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/application
+      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     env_file: .awslocal.env
     ports:
-      - 3012:8080
+      - 3012:3012
       - 5692:5678
     depends_on:
       database:
@@ -62,7 +65,12 @@ services:
         condition: service_started
     volumes:
       - './apps/funding-service-pre-award-stores:/app'
+      - './certs:/app-certs'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
+    networks:
+      default:
+        aliases:
+          - api.levellingup.gov.localhost
     profiles: [ pre, post ]
 
   pre-award-frontend:
@@ -75,20 +83,26 @@ services:
       - './apps/funding-service-pre-award-frontend:/app'
       - './certs:/app-certs'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
-    command: [ "sh", "-c", "python -m debugpy --listen 0.0.0.0:5678 -m flask run --no-debugger --host 0.0.0.0 --port 8080 --cert=/app-certs/cert.pem --key=/app-certs/key.pem" ]
+    command: > 
+      bash -c "
+        cp /app-certs/rootCA.pem /usr/local/share/ca-certificates/rootCA.crt && \
+        update-ca-certificates && \
+        python -m debugpy --listen 0.0.0.0:5678 -m flask run --no-debugger --host 0.0.0.0 --port 8080 --cert=/app-certs/cert.pem --key=/app-certs/key.pem
+      "
     stdin_open: true
     tty: true
     depends_on:
       - redis-data
       - localstack
     environment:
+      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
       - USE_LOCAL_DATA=False
-      - APPLICATION_STORE_API_HOST=http://pre-award-stores:8080/application
-      - FUND_STORE_API_HOST=http://pre-award-stores:8080/fund
+      - APPLICATION_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/application
+      - FUND_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/fund
       - FORMS_SERVICE_PUBLIC_HOST=http://form-runner.levellingup.gov.localhost:3009
       - FORMS_SERVICE_PRIVATE_HOST=http://form-runner.levellingup.gov.localhost:3009
       - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
-      - ACCOUNT_STORE_API_HOST=http://pre-award-stores:8080/account
+      - ACCOUNT_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/account
       - APPLY_HOST=frontend.levellingup.gov.localhost:3008
       - ASSESS_HOST=assessment.levellingup.gov.localhost:3010
       - AUTH_HOST=authenticator.levellingup.gov.localhost:4004
@@ -96,7 +110,7 @@ services:
       - FLASK_ENV=development
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - SECRET_KEY=dc_key
-      - ASSESSMENT_STORE_API_HOST=http://pre-award-stores:8080/assessment
+      - ASSESSMENT_STORE_API_HOST=https://api.levellingup.gov.localhost:3012/assessment
       - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008
       - ASSESSMENT_FRONTEND_HOST=https://assessment.levellingup.gov.localhost:3010
       - POST_AWARD_FRONTEND_HOST=https://find-monitoring-data.levellingup.gov.localhost:4001
@@ -131,13 +145,16 @@ services:
     ports:
       - 3009:3009
       - 9228:9228
+    volumes:
+      - './certs:/app-certs'
     environment:
+      - NODE_EXTRA_CA_CERTS=/app-certs/rootCA.pem
       - LOG_LEVEL=debug
       - JWT_AUTH_ENABLED=true
       - JWT_AUTH_COOKIE_NAME=fsd_user_token
       - JWT_REDIRECT_TO_AUTHENTICATION_URL=https://authenticator.levellingup.gov.localhost:4004/sessions/sign-out
       - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ=="
-      - 'NODE_CONFIG={"safelist": ["pre-award-stores"]}'
+      - 'NODE_CONFIG={"safelist": ["pre-award-stores", "api.levellingup.gov.localhost"]}'
       - CONTACT_US_URL=https://frontend.levellingup.gov.localhost:3008/contact_us
       - FEEDBACK_LINK=https://frontend.levellingup.gov.localhost:3008/feedback
       - COOKIE_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/cookie_policy


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-201


### Change description
We are in the process of combining pre-award-stores and pre-award-frontend.

The stores app runs over HTTP (insecure), but the frontend runs over HTTPS (secure). Flask isn't able to serve both HTTP and HTTPS traffic simultaneously, so we have decided to setup the API locally on HTTPS (even though this isn't really representative of prod). We want HTTPS locally so that we can legitimate authenticate with microsoft AD.

When the API is running on HTTPS with our self-signed cert, anything that calls the API needs to have the root certificate available so that it can trust/verify the connection. We do this by tweaking the local certificate setup to store the root CA cert in `./certs`, and then mounting this into the frontend container.

The frontend container then pulls in the root CA certificate to its local store, and switches requests out from using the python `certifi` bundle to the linux /etc/ssl/ca-certificates bundle, which now includes our root CA cert.

**Note**: all developers will need to run `make certs` again (OR manually copy the mkcert `rootCA.pem` file - which should be at `~/Library/Application Support/mkcert` on macos - into the docker runner `./certs` repo)

Related: https://github.com/communitiesuk/funding-service-pre-award-stores/pull/67