### PR TITLE
Update flask entrypoint for pre-award-stores

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       python -m fund_store.scripts.fund_round_loaders.load_fund_round_from_fab --seed_all_funds True && \
       python -m invoke assessment.seed-local-assessment-store-db && \
       python -m invoke account.seed-local-account-store && \
-      python -m debugpy --listen 0.0.0.0:5678 -m wsgi
+      python -m debugpy --listen 0.0.0.0:5678 -m flask -A app:create_app run --host 0.0.0.0 --port 8080
       "
     environment:
       - FLASK_ENV=development


### PR DESCRIPTION
### Change description
After removing connexion, the entrypoint for the Flask app has changed. Most of our docker compose services no longer use the wsgi file, so I'll follow suit there for now.

However we may revisit this in the near future.