### PR TITLE
Run localstack over HTTPS

### DIFF
--- a/.awslocal.env
+++ b/.awslocal.env
@@ -7,7 +7,7 @@ AWS_SECRET_ACCESS_KEY=fsdlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_BUCKET_NAME=fsd-bucket
 AWS_DEFAULT_REGION=eu-west-2
 AWS_REGION=eu-west-2
-AWS_ENDPOINT_OVERRIDE=http://localstack:4566
+AWS_ENDPOINT_OVERRIDE=https://localhost.localstack.cloud:4566
 AWS_SIGNATURE_VERSION=v4
 
 AWS_MSG_BUCKET_NAME=fsd-notification-bucket
@@ -16,8 +16,8 @@ AWS_MSG_BUCKET_NAME=fsd-notification-bucket
 AWS_SQS_NOTIFICATION_APP_QUEUE_NAME=notif-queue.fifo
 AWS_DLQ_NOTIFICATION_APP_QUEUE_NAME=notif-dlq.fifo
 AWS_DLQ_NOTIFICATION_MAX_RECIEVE_COUNT=3
-AWS_SQS_NOTIF_APP_PRIMARY_QUEUE_URL=http://localstack:4566/000000000000/notif-queue.fifo
-AWS_SQS_NOTIF_APP_SECONDARY_QUEUE_URL=http://localstack:4566/000000000000/notif-dlq.fifo
+AWS_SQS_NOTIF_APP_PRIMARY_QUEUE_URL=https://localhost.localstack.cloud:4566/000000000000/notif-queue.fifo
+AWS_SQS_NOTIF_APP_SECONDARY_QUEUE_URL=https://localhost.localstack.cloud:4566/000000000000/notif-dlq.fifo
 # <- Pre-award environment ->
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -307,6 +307,7 @@ services:
       - SERVICES=s3,sqs
       - PERSISTENCE=1
       - LS_LOG=warn
+      - USE_SSL=1
     ports:
       - 4566:4566 # LocalStack endpoint
       - 4510-4559:4510-4559 # external services port range


### PR DESCRIPTION
Form runner makes in-browser XHR requests to localstack, and the browser will reject these if the form runner is served over HTTPS - which it is now.