### PR TITLE
Add localhost.localstack.cloud to internal docker networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,6 +322,10 @@ services:
     volumes:
       - ./docker-localstack:/etc/localstack/init/ready.d
       - localstack:/var/lib/localstack
+    networks:
+      default:
+        aliases:
+          - localhost.localstack.cloud
 
 volumes:
   localstack: null


### PR DESCRIPTION
This is so that eg `pre-award`'s container can resolve this to the `localstack` container and hit S3.