### PR TITLE
Enabled form-runner dev autoload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,12 +157,13 @@ services:
     build:
       context: ./apps/digital-form-builder-adapter
       dockerfile: ./runner/Dockerfile
-    command: yarn runner production
+    command: yarn runner dev
     ports:
       - 3009:3009
       - 9228:9228
     volumes:
       - './certs:/app-certs'
+      - './apps/digital-form-builder-adapter/runner:/usr/src/app/digital-form-builder-adapter/runner'
     env_file:
       - .env # For the AZURE_AD_* variables
       - .awslocal.env


### PR DESCRIPTION
Enable form-runner autoload:
- call `dev` script instead of `production`
- mount the volume
