### PR TITLE
Check pre-award service is started before starting the FAB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     depends_on:
       database:
         condition: service_healthy
+      pre-award:
+        condition: service_healthy
     volumes:
       - './apps/funding-service-design-fund-application-builder:/app'
       - './certs:/app-certs'
@@ -102,6 +104,12 @@ services:
       - './apps/funding-service-pre-award:/app'
       - './certs:/app-certs'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
+    healthcheck:
+      test: curl --fail https://authenticator.levellingup.gov.localhost:4004/healthcheck || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     networks:
       default:
         aliases:


### PR DESCRIPTION
### Change description

With this PR I have added a health check for the pre award to give health check status to check also in the fab service added the pre award as a dependency service and it will wait to start till pre-award emit health check true  

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Start fab and with that pre award should start
