### PR TITLE
Migrate from levellingup to communities domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := bash
 certs:
 	mkdir -p certs
 	CAROOT=certs mkcert -install
-	CAROOT=certs mkcert -cert-file certs/cert.pem -key-file certs/key.pem "*.levellingup.gov.localhost"
+	CAROOT=certs mkcert -cert-file certs/cert.pem -key-file certs/key.pem "*.communities.gov.localhost"
 
 
 # <-- Janky block to allow `make up` / `make pre up` / `make post up`, and same for `make ... down` -->

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Required setup
 1. Copy `.env.example` to `.env` and fill in any required missing values.
 2. Edit your `/etc/hosts` file and add the following line at the end:
-  * `127.0.0.1    submit-monitoring-data.levellingup.gov.localhost find-monitoring-data.levellingup.gov.localhost authenticator.levellingup.gov.localhost assessment.levellingup.gov.localhost frontend.levellingup.gov.localhost localstack fund-application-builder.levellingup.gov.localhost api.levellingup.gov.localhost form-runner.levellingup.gov.localhost`
+  * `127.0.0.1    submit-monitoring-data.communities.gov.localhost find-monitoring-data.communities.gov.localhost authenticator.communities.gov.localhost assessment.communities.gov.localhost frontend.communities.gov.localhost localstack fund-application-builder.communities.gov.localhost api.communities.gov.localhost form-runner.communities.gov.localhost`
 3. Run `./scripts/manage-repos.sh -f` to git clone all repos into `./apps`
 4. Run `./scripts/install-venv-all-repos.sh -v -p -s` to create and populate venvs in all repos and install pre-commit hooks.
   * Note: there are some pre-existing issues with the script sometimes not picking the correct python version, may need some manual finagling until that is addressed.
@@ -43,23 +43,23 @@ To run just the post-award services, execute `make post up`.
 
 ### Service domains:
 
-* Fund Application Builder (FAB): https://fund-application-builder.levellingup.gov.localhost:3011
-  * Example URL: https://fund-application-builder.levellingup.gov.localhost:3011
+* Fund Application Builder (FAB): https://fund-application-builder.communities.gov.localhost:3011
+  * Example URL: https://fund-application-builder.communities.gov.localhost:3011
 
-* Authenticator: https://authenticator.levellingup.gov.localhost:4004
-  * Example URL: https://authenticator.levellingup.gov.localhost:4004/service/magic-links/new?fund=cof&round=r2w3
+* Authenticator: https://authenticator.communities.gov.localhost:4004
+  * Example URL: https://authenticator.communities.gov.localhost:4004/service/magic-links/new?fund=cof&round=r2w3
 
-* Apply: https://frontend.levellingup.gov.localhost:3008
-  * Example URL: https://frontend.levellingup.gov.localhost:3008/funding-round/cof/r2w3
+* Apply: https://frontend.communities.gov.localhost:3008
+  * Example URL: https://frontend.communities.gov.localhost:3008/funding-round/cof/r2w3
 
-* Assess: https://assessment.levellingup.gov.localhost:3010
-  * Example URL: https://assessment.levellingup.gov.localhost:3010/assess/assessor_tool_dashboard/
+* Assess: https://assessment.communities.gov.localhost:3010
+  * Example URL: https://assessment.communities.gov.localhost:3010/assess/assessor_tool_dashboard/
 
-* Find: https://find-monitoring-data.levellingup.gov.localhost:4001
-  * Example URL: https://find-monitoring-data.levellingup.gov.localhost:4001/download
+* Find: https://find-monitoring-data.communities.gov.localhost:4001
+  * Example URL: https://find-monitoring-data.communities.gov.localhost:4001/download
 
-* Submit: https://submit-monitoring-data.levellingup.gov.localhost:4001
-  * Example URL: https://submit-monitoring-data.levellingup.gov.localhost:4001/dashboard
+* Submit: https://submit-monitoring-data.communities.gov.localhost:4001
+  * Example URL: https://submit-monitoring-data.communities.gov.localhost:4001/dashboard
 
 ## Troubleshooting
 * Check you have the `main` branch and latest revision of each repo checked out - see the `manage-repos` section below
@@ -71,9 +71,9 @@ To run just the post-award services, execute `make post up`.
 ## Running e2e tests
 To run the e2e tests against the docker runner, set the following env vars:
 
-        export TARGET_URL_FRONTEND=https://frontend.levellingup.gov.localhost:3008
-        export TARGET_URL_AUTHENTICATOR=https://authenticator.levellingup.gov.localhost:4004
-        export TARGET_URL_FORM_RUNNER=https://form-runner.levellingup.gov.localhost:3009
+        export TARGET_URL_FRONTEND=https://frontend.communities.gov.localhost:3008
+        export TARGET_URL_AUTHENTICATOR=https://authenticator.communities.gov.localhost:4004
+        export TARGET_URL_FORM_RUNNER=https://form-runner.communities.gov.localhost:3009
 
 # Scripts
 ## manage-repos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,13 @@ services:
     env_file:
       - .env
     environment:
-      - FORM_RUNNER_INTERNAL_HOST=https://form-runner.levellingup.gov.localhost:3009
-      - FORM_RUNNER_EXTERNAL_HOST=https://form-runner.levellingup.gov.localhost:3009
+      - FORM_RUNNER_INTERNAL_HOST=https://form-runner.communities.gov.localhost:3009
+      - FORM_RUNNER_EXTERNAL_HOST=https://form-runner.communities.gov.localhost:3009
       - DATABASE_URL=postgresql://postgres:password@database:5432/fab_store # pragma: allowlist secret
       - FLASK_DEBUG=1
       - FLASK_ENV=development
       - SECRET_KEY=local # pragma: allowlist secret
-      - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
+      - AUTHENTICATOR_HOST=https://authenticator.communities.gov.localhost:4004
       - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     ports:
@@ -43,7 +43,7 @@ services:
     networks:
       default:
         aliases:
-          - fund-application-builder.levellingup.gov.localhost
+          - fund-application-builder.communities.gov.localhost
 
   pre-award:
     build:
@@ -65,29 +65,29 @@ services:
       - FLASK_ENV=development
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY:?err}
       - DATABASE_URL=postgresql://postgres:password@database:5432/pre_award_stores # pragma: allowlist secret
-      - FUND_STORE_API_HOST=https://api.levellingup.gov.localhost:4004/fund
-      - ACCOUNT_STORE_API_HOST=https://api.levellingup.gov.localhost:4004/account
-      - APPLICATION_STORE_API_HOST=https://api.levellingup.gov.localhost:4004/application
+      - FUND_STORE_API_HOST=https://api.communities.gov.localhost:4004/fund
+      - ACCOUNT_STORE_API_HOST=https://api.communities.gov.localhost:4004/account
+      - APPLICATION_STORE_API_HOST=https://api.communities.gov.localhost:4004/application
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
       - USE_LOCAL_DATA=False
-      - FORMS_SERVICE_PUBLIC_HOST=https://form-runner.levellingup.gov.localhost:3009
-      - FORMS_SERVICE_PRIVATE_HOST=https://form-runner.levellingup.gov.localhost:3009
-      - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
-      - APPLY_HOST=frontend.levellingup.gov.localhost:3008
-      - ASSESS_HOST=assessment.levellingup.gov.localhost:3010
-      - API_HOST=api.levellingup.gov.localhost:4004
-      - AUTH_HOST=authenticator.levellingup.gov.localhost:4004
+      - FORMS_SERVICE_PUBLIC_HOST=https://form-runner.communities.gov.localhost:3009
+      - FORMS_SERVICE_PRIVATE_HOST=https://form-runner.communities.gov.localhost:3009
+      - AUTHENTICATOR_HOST=https://authenticator.communities.gov.localhost:4004
+      - APPLY_HOST=frontend.communities.gov.localhost:3008
+      - ASSESS_HOST=assessment.communities.gov.localhost:3010
+      - API_HOST=api.communities.gov.localhost:4004
+      - AUTH_HOST=authenticator.communities.gov.localhost:4004
       - FLASK_DEBUG=1
       - REDIS_INSTANCE_URI=redis://redis-data:6379
       - SECRET_KEY=dc_key # pragma: allowlist secret
-      - ASSESSMENT_STORE_API_HOST=https://api.levellingup.gov.localhost:4004/assessment
-      - APPLICANT_FRONTEND_HOST=https://frontend.levellingup.gov.localhost:3008
-      - ASSESSMENT_FRONTEND_HOST=https://assessment.levellingup.gov.localhost:3010
-      - POST_AWARD_FRONTEND_HOST=https://find-monitoring-data.levellingup.gov.localhost:4001
-      - POST_AWARD_SUBMIT_HOST=https://submit-monitoring-data.levellingup.gov.localhost:4001
-      - FUND_APPLICATION_BUILDER_HOST=https://fund-application-builder.levellingup.gov.localhost:3011
-      - FORM_DESIGNER_HOST=https://form-designer.levellingup.gov.localhost:3000
-      - COOKIE_DOMAIN=.levellingup.gov.localhost
+      - ASSESSMENT_STORE_API_HOST=https://api.communities.gov.localhost:4004/assessment
+      - APPLICANT_FRONTEND_HOST=https://frontend.communities.gov.localhost:3008
+      - ASSESSMENT_FRONTEND_HOST=https://assessment.communities.gov.localhost:3010
+      - POST_AWARD_FRONTEND_HOST=https://find-monitoring-data.communities.gov.localhost:4001
+      - POST_AWARD_SUBMIT_HOST=https://submit-monitoring-data.communities.gov.localhost:4001
+      - FUND_APPLICATION_BUILDER_HOST=https://fund-application-builder.communities.gov.localhost:3011
+      - FORM_DESIGNER_HOST=https://form-designer.communities.gov.localhost:3000
+      - COOKIE_DOMAIN=.communities.gov.localhost
     ports:
       - 4004:4004
       - 3008:4004
@@ -105,7 +105,7 @@ services:
       - './certs:/app-certs'
       - '/app/.venv' # Don't overwrite this directory with local .venv because uv links won't translate in the container
     healthcheck:
-      test: curl --fail https://authenticator.levellingup.gov.localhost:4004/healthcheck || exit 1
+      test: curl --fail https://authenticator.communities.gov.localhost:4004/healthcheck || exit 1
       interval: 10s
       timeout: 5s
       retries: 5
@@ -113,10 +113,10 @@ services:
     networks:
       default:
         aliases:
-          - api.levellingup.gov.localhost
-          - frontend.levellingup.gov.localhost
-          - assessment.levellingup.gov.localhost
-          - authenticator.levellingup.gov.localhost
+          - api.communities.gov.localhost
+          - frontend.communities.gov.localhost
+          - assessment.communities.gov.localhost
+          - authenticator.communities.gov.localhost
     profiles: [ pre, post ]
 
   form-designer:
@@ -143,17 +143,17 @@ services:
       - AUTH_COOKIE_NAME=fsd_user_token
       - SSO_LOGIN_URL=/sso/login?return_app=form-designer
       - SSO_LOGOUT_URL=/sessions/sign-out
-      - AUTH_SERVICE_URL=https://authenticator.levellingup.gov.localhost:4004
+      - AUTH_SERVICE_URL=https://authenticator.communities.gov.localhost:4004
       - NODE_ENV=production
-      - PREVIEW_URL=https://form-runner.levellingup.gov.localhost:3009
-      - PUBLISH_URL=https://form-runner.levellingup.gov.localhost:3009
-      - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
-      - 'NODE_CONFIG={"safelist": ["api.levellingup.gov.localhost"]}'
+      - PREVIEW_URL=https://form-runner.communities.gov.localhost:3009
+      - PUBLISH_URL=https://form-runner.communities.gov.localhost:3009
+      - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ=="  # pragma: allowlist secret
+      - 'NODE_CONFIG={"safelist": ["api.communities.gov.localhost"]}'
       - SESSION_COOKIE_PASSWORD=12312lubv23vrg234ukv5bt3iu4trb3w4ortbc3q4orctbq34orvtb34tv  # random value for stable session encryption locally # pragma: allowlist secret
     networks:
       default:
         aliases:
-          - form-designer.levellingup.gov.localhost
+          - form-designer.communities.gov.localhost
     profiles: [ pre ]
 
   form-runner:
@@ -182,25 +182,25 @@ services:
       - LOG_LEVEL=debug
       - JWT_AUTH_ENABLED=true
       - JWT_AUTH_COOKIE_NAME=fsd_user_token
-      - JWT_REDIRECT_TO_AUTHENTICATION_URL=https://authenticator.levellingup.gov.localhost:4004/sessions/sign-out
-      - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==" # pragma: allowlist secret
-      - 'NODE_CONFIG={"safelist": ["api.levellingup.gov.localhost"]}'
-      - CONTACT_US_URL=https://frontend.levellingup.gov.localhost:3008/contact_us
-      - FEEDBACK_LINK=https://frontend.levellingup.gov.localhost:3008/feedback
-      - COOKIE_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/cookie_policy
-      - ACCESSIBILITY_STATEMENT_URL=https://frontend.levellingup.gov.localhost:3008/accessibility_statement
-      - SERVICE_START_PAGE=https://frontend.levellingup.gov.localhost:3008/account
-      - MULTIFUND_URL=https://frontend.levellingup.gov.localhost:3008/account
-      - LOGOUT_URL=https://authenticator.levellingup.gov.localhost:4004/sessions/sign-out
-      - PRIVACY_POLICY_URL=https://frontend.levellingup.gov.localhost:3008/privacy
-      - ELIGIBILITY_RESULT_URL=https://frontend.levellingup.gov.localhost:3008/eligibility-result
+      - JWT_REDIRECT_TO_AUTHENTICATION_URL=https://authenticator.communities.gov.localhost:4004/sessions/sign-out
+      - RSA256_PUBLIC_KEY_BASE64="LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZU1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTUFEQ0JpQUtCZ0hHYnRGMXlWR1crckNBRk9JZGFrVVZ3Q2Z1dgp4SEUzOGxFL2kwS1dwTXdkU0haRkZMWW5IakJWT09oMTVFaWl6WXphNEZUSlRNdkwyRTRRckxwcVlqNktFNnR2CkhyaHlQL041ZnlwU3p0OHZDajlzcFo4KzBrRnVjVzl6eU1rUHVEaXNZdG1rV0dkeEJta2QzZ3RZcDNtT0k1M1YKVkRnS2J0b0lGVTNzSWs1TkFnTUJBQUU9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ=="  # pragma: allowlist secret
+      - 'NODE_CONFIG={"safelist": ["api.communities.gov.localhost"]}'
+      - CONTACT_US_URL=https://frontend.communities.gov.localhost:3008/contact_us
+      - FEEDBACK_LINK=https://frontend.communities.gov.localhost:3008/feedback
+      - COOKIE_POLICY_URL=https://frontend.communities.gov.localhost:3008/cookie_policy
+      - ACCESSIBILITY_STATEMENT_URL=https://frontend.communities.gov.localhost:3008/accessibility_statement
+      - SERVICE_START_PAGE=https://frontend.communities.gov.localhost:3008/account
+      - MULTIFUND_URL=https://frontend.communities.gov.localhost:3008/account
+      - LOGOUT_URL=https://authenticator.communities.gov.localhost:4004/sessions/sign-out
+      - PRIVACY_POLICY_URL=https://frontend.communities.gov.localhost:3008/privacy
+      - ELIGIBILITY_RESULT_URL=https://frontend.communities.gov.localhost:3008/eligibility-result
       - SINGLE_REDIS=true
       - FORM_RUNNER_ADAPTER_REDIS_INSTANCE_URI=redis://redis-data:6379
       - SESSION_COOKIE_PASSWORD=12312lubv23vrg234ukv5bt3iu4trb3w4ortbc3q4orctbq34orvtb34tv  # random value for stable session encryption locally # pragma: allowlist secret
     networks:
       default:
         aliases:
-          - form-runner.levellingup.gov.localhost
+          - form-runner.communities.gov.localhost
     profiles: [ pre ]
 
   data-store:
@@ -229,9 +229,9 @@ services:
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/data_store # pragma: allowlist secret
-      - FIND_SERVICE_BASE_URL=https://find-monitoring-data.levellingup.gov.localhost:4001
+      - FIND_SERVICE_BASE_URL=https://find-monitoring-data.communities.gov.localhost:4001
       - REDIS_URL=redis://redis-data:6379/1
-      - AUTHENTICATOR_HOST=https://authenticator.levellingup.gov.localhost:4004
+      - AUTHENTICATOR_HOST=https://authenticator.communities.gov.localhost:4004
     restart: unless-stopped
     depends_on:
       database:
@@ -239,8 +239,8 @@ services:
     networks:
       default:
         aliases:
-          - find-monitoring-data.levellingup.gov.localhost
-          - submit-monitoring-data.levellingup.gov.localhost
+          - find-monitoring-data.communities.gov.localhost
+          - submit-monitoring-data.communities.gov.localhost
     profiles: [ post ]
 
   data-store-celery:
@@ -268,7 +268,7 @@ services:
     environment:
       - FLASK_ENV=development
       - DATABASE_URL=postgresql://postgres:password@database:5432/data_store # pragma: allowlist secret
-      - FIND_SERVICE_BASE_URL=https://find-monitoring-data.levellingup.gov.localhost:4001
+      - FIND_SERVICE_BASE_URL=https://find-monitoring-data.communities.gov.localhost:4001
       - REDIS_URL=redis://redis-data:6379/1
     stdin_open: true
     tty: true


### PR DESCRIPTION
We've migrated our production domains now, so it makes sense to update our local environments as well to keep things consistent.

This will require a bit of dev re-jigging:

- Regenerate certificates (`make certs`; but follow readme for tricky admin workarounds).
- Updating /etc/hosts