### PR TITLE
Add localstack (AWS mocking) to data-store service's dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,8 @@ services:
     depends_on:
       database:
         condition: service_healthy
+      localstack:
+        condition: service_started
     networks:
       default:
         aliases:


### PR DESCRIPTION
The data-store service requires localstack for mocking successful file upload to S3 as part of submitting monitoring reports. This is a core part of the functionality of Submit.